### PR TITLE
Fixed navigation bug for github pages.

### DIFF
--- a/config/ghpages.json
+++ b/config/ghpages.json
@@ -1,3 +1,3 @@
 {
-  "pathPrefix": "/openacr-editor/"
+  "pathPrefix": "/openacr-editor"
 }

--- a/src/components/report/ReportYAMLDownload.svelte
+++ b/src/components/report/ReportYAMLDownload.svelte
@@ -2,7 +2,7 @@
   import { evaluation } from "../../stores/evaluation.js";
   import yaml from "js-yaml";
 
-  $evaluation.title = $evaluation['product']['name'] + " " + $evaluation.title;
+  $evaluation.title = $evaluation['product']['name'] + " Accessibility Conformance Report";
 
   var reportFilename = "report";
   if ($evaluation['product']['name']) {

--- a/src/utils/createCleanEvaluation.js
+++ b/src/utils/createCleanEvaluation.js
@@ -6,7 +6,7 @@ const datestamp = new Date().toLocaleDateString();
 
 export function createCleanEvaluation() {
   const cleanEvaluation = {
-    title: "Accessibility Conformance Report",
+    title: "",
     product: {
       name: "",
       version: "",


### PR DESCRIPTION
 Also fixed title bug to not keep concatenating the title.

Closes https://github.com/GSA/openacr/issues/209

QA the navigation

1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Click the different A/Hardware/... navigation elements.
3. Confirm the tabs appear as active.

QA the title bug

1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Click 'Start new report'.
3. Switch back and forth between the report page and about page changing the product name.
4. Download the YAML file and confirm the title says '<Product> Accessibility Conformance Report'.