### PR TITLE
OpenACR chapter output

### DIFF
--- a/src/components/Criteria.svelte
+++ b/src/components/Criteria.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { Link } from "svelte-navigator";
   import Component from "./Component.svelte";
   import LinkToGuidance from "./LinkToGuidance.svelte";
   export let chapterId;
@@ -18,10 +19,21 @@
   .criteria h2 {
     font-size: 1.125em;
   }
+  .observation__meta {
+    margin-left: auto;
+    font-size: smaller;
+    align-self: baseline;
+    float: right;
+  }
 </style>
 
 <div {id} class="criteria">
   <h2>{id}: {handle}</h2>
+  <span class="observation__meta">
+    <Link to={`/report#${alt_id}-editor`}>
+      View in Report
+    </Link>
+  </span>
   <LinkToGuidance href={linkToImplementing}>Implementing {id}</LinkToGuidance>
   {#if components}
     {#each components as c}

--- a/src/components/Criteria.svelte
+++ b/src/components/Criteria.svelte
@@ -34,7 +34,7 @@
       View in Report
     </Link>
   </span>
-  <LinkToGuidance href={linkToImplementing}>Implementing {id}</LinkToGuidance>
+  <LinkToGuidance href={linkToImplementing}>Implementing {id}: {handle}</LinkToGuidance>
   {#if components}
     {#each components as c}
       <Component chapterId={chapterId} criteria={id} component={c} />

--- a/src/components/report/ReportChapter.svelte
+++ b/src/components/report/ReportChapter.svelte
@@ -1,0 +1,62 @@
+<script>
+  import { evaluation } from "../../stores/evaluation.js";
+  import { getCatalogChapter } from "../../utils/getCatalogItems.js";
+  import ReportChapterTableResult from "./ReportChapterTableResult.svelte";
+
+  export let standard;
+  export let chapterId;
+  export let download = false;
+
+  $: chapter = getCatalogChapter(chapterId);
+  const extraId = download ? "-download" : "-editor";
+</script>
+
+<style>
+  table {
+    width: 100%;
+  }
+  tr:target {
+    outline: 2px solid var(--gold);
+  }
+  thead {
+    position: sticky;
+    top: 0;
+    z-index: 1;
+  }
+  thead th {
+    position: absolute;
+    left: -9999em;
+    top: -9999em;
+  }
+  @media (min-width: 60em) {
+    thead th {
+      position: static;
+    }
+  }
+</style>
+
+<h3 id="{chapterId}{extraId}">
+  <a href="#{chapterId}{extraId}" aria-hidden="true" class="header-anchor">#</a>
+  {chapter.label}
+</h3>
+
+{#if $evaluation['chapters'][chapterId]['notes']}
+  Notes: {$evaluation['chapters'][chapterId]['notes']}
+{/if}
+
+{#if $evaluation['chapters'][chapterId]['criteria']}
+  <table class="usa-table">
+    <thead>
+    <tr>
+      <th>Criteria</th>
+      <th>Conformance Level</th>
+      <th>Remarks and Explanations</th>
+    </tr>
+    </thead>
+    <tbody>
+      {#each $evaluation['chapters'][chapterId]['criteria'] as criteria}
+        <ReportChapterTableResult {standard} {chapterId} {criteria} {download} />
+      {/each}
+    </tbody>
+  </table>
+{/if}

--- a/src/components/report/ReportChapterTableResult.svelte
+++ b/src/components/report/ReportChapterTableResult.svelte
@@ -1,0 +1,74 @@
+<script>
+  import { catalogChapterCriteria, catalogComponentLabel, levelLabel } from "../../utils/getCatalogItems.js";
+
+  export let standard;
+  export let chapterId;
+  export let criteria;
+  export let download = false;
+
+  $: catalogCriteria = catalogChapterCriteria(chapterId, criteria.num);
+  const extraId = download ? "-download" : "-editor";
+</script>
+
+<style>
+  .result-row {
+    margin-bottom: 1em;
+    border-bottom: 1px solid var(--cloudy);
+  }
+  .result-row:target {
+    outline: 2px solid var(--gold);
+  }
+  .result-row td {
+    display: block;
+    position: relative;
+    border-style: none;
+  }
+  .result-row td:nth-child(2)::before {
+    content: "";
+    width: 0.5em;
+    position: absolute;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    background-color: var(--line-grey);
+  }
+  @media (min-width: 60em) {
+    .result-row {
+      border-bottom: 0;
+    }
+    .result-row td {
+      display: table-cell;
+      border: 1px solid var(--cloudy);
+    }
+  }
+</style>
+
+<tr class="result-row" id="{criteria.num}{extraId}">
+  <td>
+    <a href="{standard.url}#{catalogCriteria.alt_id}">
+      {criteria.num} {catalogCriteria.handle}
+    </a>
+  </td>
+  <td>
+    {#if criteria.components}
+      <ul>
+        {#each criteria.components as component}
+          {#if component.adherence.level}
+            <li>{@html catalogComponentLabel(component.name, "html")}{levelLabel(component.adherence.level)}</li>
+          {/if}
+        {/each}
+      </ul>
+    {/if}
+  </td>
+  <td>
+    {#if criteria.components}
+      <ul>
+        {#each criteria.components as component}
+        {#if component.adherence.notes}
+          <li>{@html catalogComponentLabel(component.name, "html")}{component.adherence.notes}</li>
+          {/if}
+        {/each}
+      </ul>
+    {/if}
+  </td>
+</tr>

--- a/src/components/report/ReportChapterTableResult.svelte
+++ b/src/components/report/ReportChapterTableResult.svelte
@@ -36,7 +36,7 @@
 
 <tr class="result-row" id="{catalogCriteria.alt_id}{extraId}">
   <td>
-    <a href="{standard.url}#{catalogCriteria.alt_id}">
+    <a target="_blank" rel="noopener roreferrer" href="{standard.url}#{catalogCriteria.alt_id}">
       {criteria.num} {catalogCriteria.handle}
     </a>
   </td>

--- a/src/components/report/ReportChapterTableResult.svelte
+++ b/src/components/report/ReportChapterTableResult.svelte
@@ -23,15 +23,6 @@
     position: relative;
     border-style: none;
   }
-  .result-row td:nth-child(2)::before {
-    content: "";
-    width: 0.5em;
-    position: absolute;
-    top: 0;
-    left: 0;
-    bottom: 0;
-    background-color: var(--line-grey);
-  }
   @media (min-width: 60em) {
     .result-row {
       border-bottom: 0;
@@ -43,7 +34,7 @@
   }
 </style>
 
-<tr class="result-row" id="{criteria.num}{extraId}">
+<tr class="result-row" id="{catalogCriteria.alt_id}{extraId}">
   <td>
     <a href="{standard.url}#{catalogCriteria.alt_id}">
       {criteria.num} {catalogCriteria.handle}

--- a/src/components/report/ReportChapters.svelte
+++ b/src/components/report/ReportChapters.svelte
@@ -1,0 +1,17 @@
+<script>
+  import ReportChapter from "./ReportChapter.svelte";
+
+  export let standard;
+  export let download = false;
+
+  const extraId = download ? "-download" : "-editor";
+</script>
+
+<h2 id="{standard.id}{extraId}">
+  <a href="#{standard.id}{extraId}" aria-hidden="true" class="header-anchor">#</a>
+  {standard.report_heading}
+</h2>
+
+{#each standard.chapters as standardChapter}
+  <ReportChapter {standard} chapterId={standardChapter} {download} />
+{/each}

--- a/src/components/report/ReportHTMLDownload.svelte
+++ b/src/components/report/ReportHTMLDownload.svelte
@@ -4,11 +4,13 @@
 
   import ReportHeader from "./ReportHeader.svelte";
   import ReportSummary from "./ReportSummary.svelte";
+  import ReportChapters from "./ReportChapters.svelte";
   import { cleanUp } from "../../utils/cleanUpReportHTML.js";
   import { createHTMLDownload } from "../../utils/createHTMLDownload.js";
   import { validate } from "../../utils/validate.js";
   import { reportFilename } from "../../utils/reportFilename.js";
   import { license } from "../../utils/license.js";
+  import { standards } from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
 
   var title = $evaluation.title;
   const filename = reportFilename($evaluation);
@@ -50,6 +52,9 @@
   <main>
     <div class="grid-container">
       <ReportHeader {download} />
+      {#each standards as standard}
+        <ReportChapters {standard} {download} />
+      {/each}
       <ReportSummary {download} />
     </div>
   </main>

--- a/src/components/report/ReportJSONDownload.svelte
+++ b/src/components/report/ReportJSONDownload.svelte
@@ -1,11 +1,17 @@
 <script>
   import { evaluation } from "../../stores/evaluation.js";
+  import { validate } from "../../utils/validate.js";
+  import { reportFilename } from "../../utils/reportFilename.js";
+  const filename = reportFilename($evaluation);
+  const valid = validate($evaluation);
 
   $: jsonDownload = `data:application/json;charset=utf-8,${encodeURIComponent(
     JSON.stringify($evaluation)
   )}`;
 </script>
 
-<a href={jsonDownload} download="report.json" class="button">
-  Download Report (JSON)
-</a>
+{#if valid.result }
+  <a href={jsonDownload} download="{filename}.json" class="button">
+    Download Report (JSON)
+  </a>
+{/if}

--- a/src/routes/Report.svelte
+++ b/src/routes/Report.svelte
@@ -9,7 +9,6 @@
   import ReportChapters from "../components/report/ReportChapters.svelte";
   import ReportHTMLDownload from "../components/report/ReportHTMLDownload.svelte";
   import ReportYAMLDownload from "../components/report/ReportYAMLDownload.svelte";
-  import ReportMarkdownDownload from "../components/report/ReportMarkdownDownload.svelte";
   import { standards } from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
 
   import { currentPage } from "../stores/currentPage.js";
@@ -27,7 +26,7 @@
 </script>
 
 <svelte:head>
-  <title>Report | ATAG Report Tool | W3C WAI</title>
+  <title>Report | OpenACR Editor | GSA</title>
 </svelte:head>
 
 <Header>Report</Header>
@@ -35,7 +34,6 @@
 <p>
   <ReportYAMLDownload />
   <ReportHTMLDownload />
-  <ReportMarkdownDownload />
 </p>
 
 <ReportValid />

--- a/src/routes/Report.svelte
+++ b/src/routes/Report.svelte
@@ -6,10 +6,11 @@
   import ReportHeader from "../components/report/ReportHeader.svelte";
   import ReportSummary from "../components/report/ReportSummary.svelte";
   import ReportValid from "../components/report/ReportValid.svelte";
-  import ReportResults from "../components/report/ReportResults.svelte";
+  import ReportChapters from "../components/report/ReportChapters.svelte";
   import ReportHTMLDownload from "../components/report/ReportHTMLDownload.svelte";
   import ReportYAMLDownload from "../components/report/ReportYAMLDownload.svelte";
   import ReportMarkdownDownload from "../components/report/ReportMarkdownDownload.svelte";
+  import { standards } from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
 
   import { currentPage } from "../stores/currentPage.js";
 
@@ -39,4 +40,7 @@
 
 <ReportValid />
 <ReportHeader />
+{#each standards as standard}
+  <ReportChapters {standard} />
+{/each}
 <ReportSummary />

--- a/src/utils/getCatalogItems.js
+++ b/src/utils/getCatalogItems.js
@@ -11,8 +11,46 @@ export function getCatalogChapter(chapterId) {
 export function standardsIncluded(standardChapters) {
   const result = [];
   for (const standardChapter of standardChapters) {
-    const catalogChapters = getCatalogChapter(standardChapter);
-    result.push(`<li>${catalogChapters.label}</li>`);
+    const catalogChapter = getCatalogChapter(standardChapter);
+    result.push(`<li>${catalogChapter.label}</li>`);
   }
   return `<ul>${result.join("")}</ul>`;
+}
+
+export function catalogChapterCriteria(chapterId, criteriaNum) {
+  const catalogChapter = getCatalogChapter(chapterId);
+  for (const catalogChapterCriteria of catalogChapter.criteria) {
+    if (catalogChapterCriteria.id === criteriaNum) {
+      return catalogChapterCriteria;
+    }
+  }
+}
+
+export function catalogComponentLabel(componentId, templateType) {
+  if (catalog.components) {
+    for (const component of catalog.components) {
+      if (component.id === componentId) {
+        if (component.label != "") {
+          if (templateType === "html") {
+            return `<strong>${component.label}</strong>: `;
+          } else {
+            return `**${component.label}**: `;
+          }
+        }
+      }
+    }
+  }
+  return "";
+}
+
+export function levelLabel(level) {
+  if (catalog.terms) {
+    for (const terms of catalog.terms) {
+      if (terms.id === level) {
+        return terms.label;
+      }
+    }
+  }
+  // If a level is provided but has no matching terms, provide a default.
+  return "Not Applicable";
 }


### PR DESCRIPTION
Closes https://github.com/GSA/openacr/issues/227 and closes https://github.com/GSA/openacr/issues/228

QA steps:

**New report**
1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Click 'Start new report' or 'New report'.
3. Switch to the different table/chapter pages.
4. Confirm you see form fields for chapter notes.
5. Confirm you see many criteria.
6. Confirm for A/AA/AAA you see multiple components with fields for level and notes.
7. Confirm for FPC, Hardware, Software, Docs you see only one field for level and notes.
8. Adjust the level and add some notes.
9. Click the 'View report' or 'Report' tab.
10. Confirm you see a 'Valid' message.
11. Confirm the HTML on the page displays the various sections except tables, chapters, related OpenACRs. Use https://federalist-02947dd8-86df-467a-b2af-4c5b94c5b1f0.app.cloud.gov/site/gsa/opat-website/openacr/drupal-9.html as an example to compare against.
12. Click the 'Download Report (HTML)' and confirm the HTML file downloaded matches the page.

**Existing report**
1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Click 'Start new report' or 'New report'.
3. Click 'Open report'.
4. Upload a yaml file from OpenACR. Try the 'drupal-9.yaml' or any of the yaml files from https://github.com/GSA/openacr/tree/main/openacr.
5. Switch to the different table/chapter pages.
6. Confirm you see the values in the fields from the yaml file for the criteria and components.
7. Adjust the level and add some notes.
8. Click the 'View report' or 'Report' tab.
9. Confirm you see a 'Valid' message.
10. Confirm the HTML on the page displays the various sections except tables, chapters, related OpenACRs. Use https://federalist-02947dd8-86df-467a-b2af-4c5b94c5b1f0.app.cloud.gov/site/gsa/opat-website/openacr/drupal-9.html as an example to compare against.
11. Click the 'Download Report (HTML)' and confirm the HTML file downloaded matches the page.