### PR TITLE
Help text

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -6,6 +6,7 @@
   import YourReport from "./components/YourReport.svelte";
   import Report from "./routes/Report.svelte";
   import Acknowledgements from "./routes/Acknowledgements.svelte";
+  import Glossary from "./routes/Glossary.svelte";
   import Chapter from "./components/Chapter.svelte";
   import Nav from "./components/Nav.svelte";
   import NavItem from "./components/NavItem.svelte";
@@ -64,6 +65,7 @@
       </NavItem>
     {/each}
     <NavItem to="/report">Report</NavItem>
+    <NavItem to="/glossary">Glossary</NavItem>
   </Nav>
   <section
     class="app-content"
@@ -83,6 +85,9 @@
     </Route>
     <Route path="/acknowledgements">
       <Acknowledgements />
+    </Route>
+    <Route path="/glossary">
+      <Glossary />
     </Route>
   </section>
   {#if needsYourReport($currentPage)}

--- a/src/components/Chapter.svelte
+++ b/src/components/Chapter.svelte
@@ -49,7 +49,7 @@
       cols="20"
       rows="5"
       on:change={() => evaluation.updateCache($evaluation)} />
-      <HelpText type="chapters" field="notes" />
+    <HelpText type="chapters" field="notes" />
   </div>
 
   {#each currentChapter.criteria as criteria, i (criteria.id)}

--- a/src/components/Chapter.svelte
+++ b/src/components/Chapter.svelte
@@ -2,6 +2,7 @@
   import { onMount } from "svelte";
   import { useLocation } from "svelte-navigator";
   import Header from "./Header.svelte";
+  import HelpText from "../components/HelpText.svelte";
   import Criteria from "./Criteria.svelte";
   import LinkToGuidance from "./LinkToGuidance.svelte";
   import Pager from "./Pager.svelte";
@@ -48,6 +49,7 @@
       cols="20"
       rows="5"
       on:change={() => evaluation.updateCache($evaluation)} />
+      <HelpText type="chapters" field="notes" />
   </div>
 
   {#each currentChapter.criteria as criteria, i (criteria.id)}

--- a/src/components/Component.svelte
+++ b/src/components/Component.svelte
@@ -1,6 +1,7 @@
 <script>
   import { evaluation } from "../stores/evaluation.js";
   import { components, terms } from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
+  import HelpText from "../components/HelpText.svelte";
 
   export let chapterId;
   export let criteria;
@@ -13,7 +14,7 @@
 
 <style>
   select {
-    margin-bottom: 1.5em;
+    display: block;
   }
 </style>
 
@@ -25,21 +26,24 @@
 
 {#if currentEvaluationCriteria }
   {#if currentEvaluationComponent }
-    <label for="evaluation-{criteria}-{component}-level">
-      Level
-      <span class="visuallyhidden">for {criteria} {component}</span>
-    </label>
-    <select
-      id="evaluation-{criteria}-{component}-level"
-      name="evaluation-{criteria}-{component}-level"
-      bind:value={currentEvaluationComponent['adherence']['level']}
-      on:blur={() => {
-        evaluation.updateCache($evaluation);
-      }}>
-      {#each terms as term}
-        <option name="option-evaluation-{criteria}-{component}-level-{term.id}" value={term.id}>{term.label}</option>
-      {/each}
-    </select>
+    <div class="field">
+      <label for="evaluation-{criteria}-{component}-level">
+        Level
+        <span class="visuallyhidden">for {criteria} {component}</span>
+      </label>
+      <select
+        id="evaluation-{criteria}-{component}-level"
+        name="evaluation-{criteria}-{component}-level"
+        bind:value={currentEvaluationComponent['adherence']['level']}
+        on:blur={() => {
+          evaluation.updateCache($evaluation);
+        }}>
+        {#each terms as term}
+          <option name="option-evaluation-{criteria}-{component}-level-{term.id}" value={term.id}>{term.label}</option>
+        {/each}
+      </select>
+      <HelpText type="components" field="level" />
+    </div>
 
     <div class="field">
       <label for="evaluation-{criteria}-{component}-notes">Notes</label>
@@ -47,6 +51,7 @@
         bind:value={currentEvaluationComponent['adherence']['notes']}
         id="evaluation-{criteria}-{component}-notes"
         on:change={() => evaluation.updateCache($evaluation)} />
+      <HelpText type="components" field="notes" />
     </div>
   {:else}
     <p>Could not find component '{component}' for critera '{criteria}' in '{chapterId}'.</p>

--- a/src/components/HelpText.svelte
+++ b/src/components/HelpText.svelte
@@ -1,0 +1,20 @@
+<script>
+  import helpText from "../data/helpText.yaml";
+
+  export let type;
+  export let field;
+</script>
+
+<style>
+  .help-text {
+    color: #868686;
+    font-style: italic;
+    font-size: 0.85em;
+  }
+</style>
+
+{#if helpText[type][field].help}
+  <div class="help-text">
+    {helpText[type][field].help}
+  </div>
+{/if}

--- a/src/components/HelpText.svelte
+++ b/src/components/HelpText.svelte
@@ -13,8 +13,9 @@
   }
 </style>
 
-{#if helpText[type][field].help}
+{#if helpText[type] &&
+     helpText[type][field]}
   <div class="help-text">
-    {helpText[type][field].help}
+    {helpText[type][field]}
   </div>
 {/if}

--- a/src/data/helpText.yaml
+++ b/src/data/helpText.yaml
@@ -1,5 +1,31 @@
 product:
-  name:
-    help: ""
-  version:
-    help: "Provide version if available."
+  name: ""
+  version: "Provide version if available."
+  description: ""
+author:
+  name: ""
+  company_name: ""
+  address: ""
+  email: ""
+  phone: ""
+  website: ""
+vendor:
+  name: ""
+  company_name: ""
+  address: ""
+  email: ""
+  phone: ""
+  website: ""
+report:
+  report_date: ""
+  notes: ""
+  evaluation_methods_used: ""
+  legal_disclaimer: ""
+  repository: ""
+  feedback: ""
+  license: ""
+chapter:
+  notes: ""
+components:
+  level: ""
+  notes: ""

--- a/src/data/helpText.yaml
+++ b/src/data/helpText.yaml
@@ -1,0 +1,5 @@
+product:
+  name:
+    help: ""
+  version:
+    help: "Provide version if available."

--- a/src/index.html
+++ b/src/index.html
@@ -76,7 +76,7 @@
             [content-end] minmax(16px, 1fr)
             [complete-end];
         }
-        #conformance-tool {
+        #openacr-editor {
           padding: 0;
         }
       }
@@ -163,7 +163,7 @@
       </div>
     </header>
     <main>
-      <div id="conformance-tool" class="default-grid leftcol">
+      <div id="openacr-editor" class="default-grid leftcol">
         <!-- app 'renders' here -->
       </div>
     </main>

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,7 @@
 import App from "./App.svelte";
-import atag from "./data/atag.js";
 
 const app = new App({
-  target: document.getElementById("conformance-tool"),
+  target: document.getElementById("openacr-editor"),
 });
 
 export default app;

--- a/src/routes/About.svelte
+++ b/src/routes/About.svelte
@@ -78,6 +78,7 @@
     bind:value={$evaluation['product']['description']}
     id="evaluation-product-description"
     on:change={() => evaluation.updateCache($evaluation)} />
+  <HelpText type="product" field="description" />
 </div>
 
 <h2>Author</h2>
@@ -89,6 +90,7 @@
     bind:value={$evaluation['author']['name']}
     id="evaluation-author-name"
     on:blur={() => evaluation.updateCache($evaluation)} />
+  <HelpText type="author" field="name" />
 </div>
 
 <div class="field">
@@ -98,6 +100,7 @@
     bind:value={$evaluation['author']['company_name']}
     id="evaluation-author-company"
     on:blur={() => evaluation.updateCache($evaluation)} />
+  <HelpText type="author" field="company_name" />
 </div>
 
 <div class="field">
@@ -107,6 +110,7 @@
     bind:value={$evaluation['author']['address']}
     id="evaluation-author-address"
     on:blur={() => evaluation.updateCache($evaluation)} />
+    <HelpText type="author" field="address" />
 </div>
 
 <div class="field">
@@ -116,6 +120,7 @@
     bind:value={$evaluation['author']['email']}
     id="evaluation-author-email"
     on:blur={() => evaluation.updateCache($evaluation)} />
+    <HelpText type="author" field="email" />
 </div>
 
 <div class="field">
@@ -125,6 +130,7 @@
     bind:value={$evaluation['author']['phone']}
     id="evaluation-author-phone"
     on:blur={() => evaluation.updateCache($evaluation)} />
+    <HelpText type="author" field="phone" />
 </div>
 
 <div class="field">
@@ -134,6 +140,7 @@
     bind:value={$evaluation['author']['website']}
     id="evaluation-author-website"
     on:blur={() => evaluation.updateCache($evaluation)} />
+    <HelpText type="author" field="website" />
 </div>
 
 <h2>Vendor</h2>
@@ -145,6 +152,7 @@
     bind:value={$evaluation['vendor']['name']}
     id="evaluation-vendor-name"
     on:blur={() => evaluation.updateCache($evaluation)} />
+    <HelpText type="vendor" field="name" />
 </div>
 
 <div class="field">
@@ -154,6 +162,7 @@
     bind:value={$evaluation['vendor']['company_name']}
     id="evaluation-vendor-company"
     on:blur={() => evaluation.updateCache($evaluation)} />
+    <HelpText type="vendor" field="company_name" />
 </div>
 
 <div class="field">
@@ -163,6 +172,7 @@
     bind:value={$evaluation['vendor']['address']}
     id="evaluation-vendor-address"
     on:blur={() => evaluation.updateCache($evaluation)} />
+    <HelpText type="vendor" field="address" />
 </div>
 
 <div class="field">
@@ -172,6 +182,7 @@
     bind:value={$evaluation['vendor']['email']}
     id="evaluation-vendor-email"
     on:blur={() => evaluation.updateCache($evaluation)} />
+    <HelpText type="vendor" field="email" />
 </div>
 
 <div class="field">
@@ -181,6 +192,7 @@
     bind:value={$evaluation['vendor']['phone']}
     id="evaluation-vendor-phone"
     on:blur={() => evaluation.updateCache($evaluation)} />
+    <HelpText type="vendor" field="phone" />
 </div>
 
 <div class="field">
@@ -190,6 +202,7 @@
     bind:value={$evaluation['vendor']['website']}
     id="evaluation-vendor-website"
     on:blur={() => evaluation.updateCache($evaluation)} />
+    <HelpText type="vendor" field="website" />
 </div>
 
 <h2>ACR Report Details</h2>
@@ -203,6 +216,7 @@
     bind:value={$evaluation['report_date']}
     id="evaluation-report-date"
     on:change={() => evaluation.updateCache($evaluation)} />
+    <HelpText type="report" field="report_date" />
 </div>
 
 <div class="field">
@@ -211,6 +225,7 @@
     bind:value={$evaluation['notes']}
     id="evaluation-notes"
     on:change={() => evaluation.updateCache($evaluation)} />
+    <HelpText type="report" field="notes" />
 </div>
 
 <div class="field">
@@ -219,6 +234,7 @@
     bind:value={$evaluation['evaluation_methods_used']}
     id="evaluation-evaluation-methods-used"
     on:change={() => evaluation.updateCache($evaluation)} />
+    <HelpText type="report" field="evaluation_methods_used" />
 </div>
 
 <div class="field">
@@ -227,6 +243,7 @@
     bind:value={$evaluation['legal_disclaimer']}
     id="evaluation-legal-disclaimer"
     on:change={() => evaluation.updateCache($evaluation)} />
+    <HelpText type="report" field="legal_disclaimer" />
 </div>
 
 <div class="field">
@@ -236,6 +253,7 @@
     bind:value={$evaluation['repository']}
     id="evaluation-repository"
     on:blur={() => evaluation.updateCache($evaluation)} />
+    <HelpText type="report" field="repository" />
 </div>
 
 <div class="field">
@@ -245,11 +263,13 @@
     bind:value={$evaluation['feedback']}
     id="evaluation-feedback"
     on:blur={() => evaluation.updateCache($evaluation)} />
+    <HelpText type="report" field="feedback" />
 </div>
 
 <div class="field">
   <label for="evaluation-license">License</label>
   <Select id="evaluation-license" inputStyles="border: 1px solid var(--grey);" items={spdxLicenses} value={$evaluation['license']} on:select={handleLicenseSelect} on:clear={handleLicenseClear} />
+  <HelpText type="report" field="license" />
 </div>
 
 <!-- TODO add related ACR URLs as an array of values. -->

--- a/src/routes/About.svelte
+++ b/src/routes/About.svelte
@@ -110,7 +110,7 @@
     bind:value={$evaluation['author']['address']}
     id="evaluation-author-address"
     on:blur={() => evaluation.updateCache($evaluation)} />
-    <HelpText type="author" field="address" />
+  <HelpText type="author" field="address" />
 </div>
 
 <div class="field">
@@ -120,7 +120,7 @@
     bind:value={$evaluation['author']['email']}
     id="evaluation-author-email"
     on:blur={() => evaluation.updateCache($evaluation)} />
-    <HelpText type="author" field="email" />
+  <HelpText type="author" field="email" />
 </div>
 
 <div class="field">
@@ -130,7 +130,7 @@
     bind:value={$evaluation['author']['phone']}
     id="evaluation-author-phone"
     on:blur={() => evaluation.updateCache($evaluation)} />
-    <HelpText type="author" field="phone" />
+  <HelpText type="author" field="phone" />
 </div>
 
 <div class="field">
@@ -140,7 +140,7 @@
     bind:value={$evaluation['author']['website']}
     id="evaluation-author-website"
     on:blur={() => evaluation.updateCache($evaluation)} />
-    <HelpText type="author" field="website" />
+  <HelpText type="author" field="website" />
 </div>
 
 <h2>Vendor</h2>
@@ -152,7 +152,7 @@
     bind:value={$evaluation['vendor']['name']}
     id="evaluation-vendor-name"
     on:blur={() => evaluation.updateCache($evaluation)} />
-    <HelpText type="vendor" field="name" />
+  <HelpText type="vendor" field="name" />
 </div>
 
 <div class="field">
@@ -162,7 +162,7 @@
     bind:value={$evaluation['vendor']['company_name']}
     id="evaluation-vendor-company"
     on:blur={() => evaluation.updateCache($evaluation)} />
-    <HelpText type="vendor" field="company_name" />
+  <HelpText type="vendor" field="company_name" />
 </div>
 
 <div class="field">
@@ -172,7 +172,7 @@
     bind:value={$evaluation['vendor']['address']}
     id="evaluation-vendor-address"
     on:blur={() => evaluation.updateCache($evaluation)} />
-    <HelpText type="vendor" field="address" />
+  <HelpText type="vendor" field="address" />
 </div>
 
 <div class="field">
@@ -182,7 +182,7 @@
     bind:value={$evaluation['vendor']['email']}
     id="evaluation-vendor-email"
     on:blur={() => evaluation.updateCache($evaluation)} />
-    <HelpText type="vendor" field="email" />
+  <HelpText type="vendor" field="email" />
 </div>
 
 <div class="field">
@@ -192,7 +192,7 @@
     bind:value={$evaluation['vendor']['phone']}
     id="evaluation-vendor-phone"
     on:blur={() => evaluation.updateCache($evaluation)} />
-    <HelpText type="vendor" field="phone" />
+  <HelpText type="vendor" field="phone" />
 </div>
 
 <div class="field">
@@ -202,7 +202,7 @@
     bind:value={$evaluation['vendor']['website']}
     id="evaluation-vendor-website"
     on:blur={() => evaluation.updateCache($evaluation)} />
-    <HelpText type="vendor" field="website" />
+  <HelpText type="vendor" field="website" />
 </div>
 
 <h2>ACR Report Details</h2>
@@ -216,7 +216,7 @@
     bind:value={$evaluation['report_date']}
     id="evaluation-report-date"
     on:change={() => evaluation.updateCache($evaluation)} />
-    <HelpText type="report" field="report_date" />
+  <HelpText type="report" field="report_date" />
 </div>
 
 <div class="field">
@@ -225,7 +225,7 @@
     bind:value={$evaluation['notes']}
     id="evaluation-notes"
     on:change={() => evaluation.updateCache($evaluation)} />
-    <HelpText type="report" field="notes" />
+  <HelpText type="report" field="notes" />
 </div>
 
 <div class="field">
@@ -234,7 +234,7 @@
     bind:value={$evaluation['evaluation_methods_used']}
     id="evaluation-evaluation-methods-used"
     on:change={() => evaluation.updateCache($evaluation)} />
-    <HelpText type="report" field="evaluation_methods_used" />
+  <HelpText type="report" field="evaluation_methods_used" />
 </div>
 
 <div class="field">
@@ -243,7 +243,7 @@
     bind:value={$evaluation['legal_disclaimer']}
     id="evaluation-legal-disclaimer"
     on:change={() => evaluation.updateCache($evaluation)} />
-    <HelpText type="report" field="legal_disclaimer" />
+  <HelpText type="report" field="legal_disclaimer" />
 </div>
 
 <div class="field">
@@ -253,7 +253,7 @@
     bind:value={$evaluation['repository']}
     id="evaluation-repository"
     on:blur={() => evaluation.updateCache($evaluation)} />
-    <HelpText type="report" field="repository" />
+  <HelpText type="report" field="repository" />
 </div>
 
 <div class="field">
@@ -263,7 +263,7 @@
     bind:value={$evaluation['feedback']}
     id="evaluation-feedback"
     on:blur={() => evaluation.updateCache($evaluation)} />
-    <HelpText type="report" field="feedback" />
+  <HelpText type="report" field="feedback" />
 </div>
 
 <div class="field">

--- a/src/routes/About.svelte
+++ b/src/routes/About.svelte
@@ -2,6 +2,7 @@
   import { onMount } from "svelte";
   import Header from "../components/Header.svelte";
   import Pager from "../components/Pager.svelte";
+  import HelpText from "../components/HelpText.svelte";
   import PagerLink from "../components/PagerLink.svelte";
   import { evaluation } from "../stores/evaluation.js";
   import { currentPage } from "../stores/currentPage.js";
@@ -58,6 +59,7 @@
     bind:value={$evaluation['product']['name']}
     id="evaluation-product-name"
     on:blur={() => evaluation.updateCache($evaluation)} />
+  <HelpText type="product" field="name" />
 </div>
 
 <div class="field">
@@ -67,6 +69,7 @@
     bind:value={$evaluation['product']['version']}
     id="evaluation-product-version"
     on:blur={() => evaluation.updateCache($evaluation)} />
+  <HelpText type="product" field="version" />
 </div>
 
 <div class="field">

--- a/src/routes/Glossary.svelte
+++ b/src/routes/Glossary.svelte
@@ -1,0 +1,19 @@
+<script>
+  import { onMount } from "svelte";
+  import Header from "../components/Header.svelte";
+  import { currentPage } from "../stores/currentPage.js";
+
+  onMount(() => {
+    currentPage.update(currentPage => "Glossary");
+  });
+</script>
+
+<svelte:head>
+  <title>Glossary| OpenACR Editor | GSA</title>
+</svelte:head>
+
+<Header>Glossary</Header>
+
+<p>
+  A glossary of terms.
+</p>


### PR DESCRIPTION
Changes:
* Added help text component and styled to match Drupal.
* The component will appear under all form fields and the values will come from `helpText.yaml` file matching a simple key/value pairing. I only added 'Version' help text as an example for now.
* Added glossary page.
* Replaced an old Id and fixed the styling around component label.

**Help text QA**

1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Click 'Start new report' or 'New report'.
3. Switch to the About page.
4. Confirm you see help text below the 'Version' field. Comment on whether the styling works or needs tweaking.

**Glossary**
1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Click 'Glossary' page
3. Confirm the page loads.

Part of https://github.com/GSA/openacr/issues/211