### PR TITLE
W3C license attribution

### DIFF
--- a/.pa11yci
+++ b/.pa11yci
@@ -9,7 +9,10 @@
     "http://localhost:10001/about",
     "http://localhost:10001/acknowledgements",
     "http://localhost:10001/glossary",
-    "http://localhost:10001/report",
+    {
+      "url": "http://localhost:10001/report",
+      "timeout": 50000
+    },
     "http://localhost:10001/chapter/success_criteria_level_a",
     "http://localhost:10001/chapter/success_criteria_level_aa",
     "http://localhost:10001/chapter/success_criteria_level_aaa",

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -1,0 +1,6 @@
+# This is the official list of project authors for copyright purposes.
+# This file is distinct from the CONTRIBUTORS.txt file.
+# See the latter for an explanation.
+#
+# Names should be added to this file as:
+# Name or Organization <email address>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,109 @@
+This document is about how to contribute to the GSA's OpenACR Editor. This process looks a bit different depending on whether you're a GSA employee or not. Here's what you can find in this doc:
+
+- [Public contributions](#public-contributions)
+- [GSA contributions](#gsa-contributions)
+  - [Branches](#branches)
+  - [Front end architecture](#front-end-architecture)
+  - [Standards and benchmarks](#standards-and-benchmarks)
+- [Public domain](#public-domain)
+
+No matter who you are, if you spot an error, omission, or bug, you're welcome to open an issue in this repo!
+
+Before contributing, we encourage you to read our CONTRIBUTING policy (you are here), our [LICENSE.md](LICENSE.md), and our [README.md](README.md).
+
+## Public contributions
+
+We're so glad you're thinking about contributing to an GSA open source project! If you're unsure about anything, just submit an issue with your question. The worst that can happen is you'll be politely asked to change something. We love all friendly contributions.
+
+We want to ensure a welcoming environment for all of our projects. Our staff follow the [TTS Code of Conduct](https://handbook.tts.gsa.gov/code-of-conduct/) and all contributors should do the same.
+
+- If you see an error or have feedback, the best way to let us know is to file an issue.
+- To contribute a specific change, contributors will need to fork this repository.
+
+### Contribution guidelines
+
+OpenACR Editor is maintained by the General Services Administration (GSA). We encourage contributions consistent with the project's principles:
+
+- Be free and open source.
+- Be accessible, and meet or exceed the requirements of Section 508.
+- Have good multilingual support.
+- Encourage continuous improvement — strive to be better, not necessarily perfect.
+
+We accept pull requests that improve OpenACR Editor and align with these principles. We review all contributions for code quality and consistency and we may reject contributions that do not meet our standards for code quality or conform to our principles. We will evaluate all contributions for the following aspects of code quality:
+
+- Compiles without errors
+- Passes code scanning and continuous integration tests
+- Follows security, privacy & accessibility best practices
+- Is legible and understandable
+- Is consistent with the existing codebase
+
+Any contributors will be responsible for updating `AUTHORS.txt` and `CONTRIBUTORS.txt` as necessary. We'll review these files as part of the code review process.
+
+[`AUTHORS.txt`](AUTHORS.txt) is the official list of project authors for copyright purposes.
+
+[`CONTRIBUTORS.txt`](CONTRIBUTORS.txt) is the list of people who have contributed to this project, and includes those not listed in `AUTHORS.txt` because they are not copyright authors. For example, company employees may be listed here because their company holds the copyright and is listed in `AUTHORS.txt`.
+
+We may request changes from the author for any contributions that do not pass this evaluation. Contributions that do not pass this evaluation may be rejected. If you're unsure about anything, just ask.
+
+## GSA contributions
+
+### Branches
+
+Any GSA team member should be able to make a branch of the site and submit a pull request. Doing so will also generate a preview URL we can use to inspect your changes. Please do not submit a pull request from a fork of the site, because that does not permit us to inspect your changes.
+
+Because new blog posts are published several times a week, we use several branches to manage parallel work in a predictable way:
+
+- Submit **new design work, content changes, and features** as pull requests to the `dev` branch. This will allow us to test and review batches of changes before deploying them.
+
+**The `master`, `staging`, and `production` branches are protected.** Only administrators of the repo can push directly to those branches.
+
+### Submitting pull requests
+
+To fill out the template, please start by attaching any issues your PR addresses. If the PR changes are not associated with an issue, please leave a brief message detailing what was wrong with the site before, and how it _should_ be.
+
+Complete the PR message by detailing all fixes and tagging GitHub users who should review the work, with a note about what they should be reviewing. In general:
+
+- If you are not an admin, tag someone who you would like to review and merge your PR
+- If you are an admin for the repo, you are responsible for merging your own PRs **after they have been reviewed and approved by someone else on the team**
+- If you have been asked to review a PR, leave a clear message indicating your approval, either through the formal PR review feature or by commenting (at the very least, with a note saying `LGTM`, or "Looks good to me")
+- If your PR includes many small, incremental commits, consider squashing them
+
+### Front end architecture
+
+We default to using [semantic HTML5](https://developer.mozilla.org/en-US/docs/Glossary/Semantics).
+
+#### CSS
+
+CSS methodology is inherited from the WDS, which inherits mostly from the [18f front end guide](https://pages.18f.gov/frontend/css-coding-styleguide/architecture/).
+
+- Use [18F modifed BEM naming convention](https://pages.18f.gov/frontend/css-coding-styleguide/naming/)
+- Componentized CSS: start with tag rules and only becomes more specific as necessary, using component classes
+
+#### JavaScript
+
+- Ruby gems is used for front end dependency management
+
+## Accessibility
+
+To test the site locally for accessibility errors.
+
+## Standards and benchmarks
+
+### Device and browser support
+
+- The website supports the latest modern web browsers
+- The website should be designed with a mobile-first approach
+
+### Performance
+
+Each of the following events should load in under a second:
+
+- Time to blog post image
+- Time to main image and callout text
+- Time until first blog post title shows up on page with all blog posts
+
+## Public domain
+
+For detailed license information, see [LICENSE](LICENSE.md).
+
+All contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,0 +1,10 @@
+# This is the list of people who have contributed to this project,
+# and includes those not listed in AUTHORS.txt because they are not
+# copyright authors. For example, company employees may be listed
+# here because their company holds the copyright and is listed there.
+#
+# When adding J Random Contributor's name to this file, either J's
+# name or J's organization's name should be added to AUTHORS.txt
+#
+# Names should be added to this file as:
+# Name <email address>

--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,0 @@
-The W3C SOFTWARE NOTICE AND LICENSE (W3C)
-
-	https://www.w3.org/Consortium/Legal/copyright-software

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,37 @@
+This project includes a mix of the following:
+
+- Open source works that are not in the public domain
+- Open source work by the U.S. government that is in the public domain
+
+## Parts of this project that are not in the public domain
+
+Presently some W3C data files and derrivitive files are included which are released under the [W3C SOFTWARE AND DOCUMENT NOTICE AND LICENSE](https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document).
+
+Copyright © 2021 W3C® (MIT, ERCIM, Keio, Beihang).
+
+## The rest of this project is in the worldwide public domain
+
+As a work of the United States government, this project is in the public domain within the United States.
+
+Additionally, we waive copyright and related rights in the work worldwide through the [CC0 1.0 Universal public domain dedication](https://creativecommons.org/publicdomain/zero/1.0/).
+
+### CC0 1.0 Universal Summary
+
+This is a human-readable summary of the
+[Legal Code (read the full text)](https://creativecommons.org/publicdomain/zero/1.0/legalcode).
+
+#### No copyright
+
+The person who associated a work with this deed has dedicated the work to the public domain by waiving all of his or her rights to the work worldwide under copyright law, including all related and neighboring rights, to the extent allowed by law.
+
+You can copy, modify, distribute and perform the work, even for commercial purposes, all without asking permission.
+
+#### Other information
+
+In no way are the patent or trademark rights of any person affected by CC0, nor are the rights that other persons may have in the work or in how the work is used, such as publicity or privacy rights.
+
+Unless expressly stated otherwise, the person who associated a work with this deed makes no warranties about the work, and disclaims liability for all uses of the work, to the fullest extent permitted by applicable law. When using or citing the work, you should not imply endorsement by the author or the affirmer.
+
+### Contributions to this project
+
+As stated in [CONTRIBUTING](CONTRIBUTING.md), all contributions to this project will be released under the CC0 dedication. By submitting a pull request, you are agreeing to comply with this waiver of copyright interest.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ With this tool, people can generate Accessibility Conformance Report in the [Ope
 
 ## ATAG Report Tool (ART)
 
-This editor is based on the [W3C ATAG Report Tool (ART)](https://github.com/w3c/wai-atag-report-tool).
+This software includes material copied from or derived from [W3C ATAG Report Tool (ART)](https://github.com/w3c/wai-atag-report-tool) and Copyright © 2021 W3C® (MIT, ERCIM, Keio, Beihang).
+
+[W3C Software notice and license](https://www.w3.org/Consortium/Legal/copyright-software).
 
 ## Development
 

--- a/src/index.html
+++ b/src/index.html
@@ -231,6 +231,16 @@
             >U.S. General Services Administration (GSA)</a
           >. The content is the responsibility of the author.
         </p>
+        <p>
+          This software includes material copied from or derived from
+          <a href="https://github.com/w3c/wai-atag-report-tool"
+            >W3C ATAG Report Tool (ART)</a
+          >
+          and Copyright © 2021 W3C® (MIT, ERCIM, Keio, Beihang).
+          <a href="https://www.w3.org/Consortium/Legal/copyright-software"
+            >W3C Software notice and license</a
+          >.
+        </p>
       </div>
     </footer>
     <!-- Analytics code -->


### PR DESCRIPTION
Also copied over contributions from OpenACR see https://github.com/GSA/openacr/pull/214

Closes https://github.com/GSA/openacr/issues/203

**QA site**

1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Confirm the footer references WCAG ATAG report tool and W3C copyright and link to their license.
 