### PR TITLE
Add none option

### DIFF
--- a/cypress/integration/about.test.js
+++ b/cypress/integration/about.test.js
@@ -17,6 +17,12 @@ describe("About", () => {
     cy.get("h2.your-report__heading").should("contain", "Report for Drupal");
   });
 
+  it("default report date is today and in local format", () => {
+    const today = new Date().toLocaleDateString();
+
+    cy.get("#evaluation-report-date").should("have.value", today);
+  });
+
   it("license dropdown is searchaeble", () => {
     cy.get("#evaluation-license")
       .type("creative commons")

--- a/cypress/integration/chapter.test.js
+++ b/cypress/integration/chapter.test.js
@@ -36,7 +36,23 @@ describe("Chapter", () => {
 
     cy.get(progressBarA).should("contain", "1 of 100");
 
+    cy.get(nonTextContentWebComponentLevelField).select("Partially Supports");
+
+    cy.get(progressBarA).should("contain", "1 of 100");
+
+    cy.get(nonTextContentWebComponentLevelField).select("Does Not Support");
+
+    cy.get(progressBarA).should("contain", "1 of 100");
+
+    cy.get(nonTextContentWebComponentLevelField).select("Not Applicable");
+
+    cy.get(progressBarA).should("contain", "1 of 100");
+
     cy.get(nonTextContentWebComponentLevelField).select("Not Evaluated");
+
+    cy.get(progressBarA).should("contain", "1 of 100");
+
+    cy.get(nonTextContentWebComponentLevelField).select("");
 
     cy.get(progressBarA).should("contain", "0 of 100");
   });

--- a/cypress/integration/import.test.js
+++ b/cypress/integration/import.test.js
@@ -5,10 +5,10 @@ describe("Import", () => {
     {
       filename: "drupal-9.yaml",
       reportname: "Drupal",
-      total: 183,
+      total: 184,
       success_criteria_level_a: 100,
       success_criteria_level_aa: 48,
-      success_criteria_level_aaa: 22,
+      success_criteria_level_aaa: 23,
       functional_performance_criteria: 9,
       hardware: 0,
       software: 0,

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "CC0-1.0",
       "dependencies": {
-        "@openacr/openacr": "^0.3.0",
+        "@openacr/openacr": "^0.3.1",
         "core-js": "3",
         "marked": "^0.8.2",
         "svelte-navigator": "^3.0.8"
@@ -1082,9 +1082,9 @@
       }
     },
     "node_modules/@openacr/openacr": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@openacr/openacr/-/openacr-0.3.0.tgz",
-      "integrity": "sha512-HxW9KnLp+KlmEDVi5/thV+tN32VCPsrRSPjpvi/qZmwbPzzO42LKWyY6h3ALHVn5wlxztzGGH57meNq+yG6evw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@openacr/openacr/-/openacr-0.3.1.tgz",
+      "integrity": "sha512-fV7vD2Id/SQ828Erm01o33oZ//6KnB+MAJZBtTeDMqtPLbJLzLtOmUHYA+JMEjh2xJVja+ifkNcjODCHguWI8w==",
       "dependencies": {
         "ajv": "^8.6.1",
         "fs-extra": "^10.0.0",
@@ -7115,9 +7115,9 @@
       }
     },
     "@openacr/openacr": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@openacr/openacr/-/openacr-0.3.0.tgz",
-      "integrity": "sha512-HxW9KnLp+KlmEDVi5/thV+tN32VCPsrRSPjpvi/qZmwbPzzO42LKWyY6h3ALHVn5wlxztzGGH57meNq+yG6evw==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@openacr/openacr/-/openacr-0.3.1.tgz",
+      "integrity": "sha512-fV7vD2Id/SQ828Erm01o33oZ//6KnB+MAJZBtTeDMqtPLbJLzLtOmUHYA+JMEjh2xJVja+ifkNcjODCHguWI8w==",
       "requires": {
         "ajv": "^8.6.1",
         "fs-extra": "^10.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "browserslist": "> 0.25%, not dead",
   "dependencies": {
-    "@openacr/openacr": "^0.3.0",
+    "@openacr/openacr": "^0.3.1",
     "core-js": "3",
     "marked": "^0.8.2",
     "svelte-navigator": "^3.0.8"

--- a/src/components/Component.svelte
+++ b/src/components/Component.svelte
@@ -41,6 +41,7 @@
         on:blur={() => {
           evaluation.updateCache($evaluation);
         }}>
+        <option name="option-evaluation-{criteria}-{component}-level-none" value="">- Select -</option>
         {#each terms as term}
           <option name="option-evaluation-{criteria}-{component}-level-{term.id}" value={term.id}>{term.label}</option>
         {/each}

--- a/src/components/YourReport.svelte
+++ b/src/components/YourReport.svelte
@@ -100,7 +100,7 @@
     outline-color: var(--w3c-blue);
   }
   .your-report__progress-by-principle {
-    columns: 2;
+    columns: 1;
     column-gap: 1.5em;
     margin: 2.25em 0 1.75em 0;
     padding: 0;

--- a/src/stores/evaluation.js
+++ b/src/stores/evaluation.js
@@ -4,7 +4,7 @@ import { createCleanEvaluation } from "../utils/createCleanEvaluation.js";
 const storageName = "openacr_editor_store";
 
 // update this number whenever new things added to the data model to cachebust [remove this when stable]
-const DATA_MODEL = "20";
+const DATA_MODEL = "21";
 
 let fresh = true;
 

--- a/src/utils/createCleanEvaluation.js
+++ b/src/utils/createCleanEvaluation.js
@@ -46,7 +46,7 @@ export function createCleanEvaluation() {
         components.push({
           name: component,
           adherence: {
-            level: "not-evaluated",
+            level: "",
             notes: "",
           },
         });

--- a/src/utils/getEvaluatedItems.js
+++ b/src/utils/getEvaluatedItems.js
@@ -11,7 +11,7 @@ export function getProgressPerChapter(evaluation) {
           if (
             component["adherence"] &&
             component["adherence"]["level"] &&
-            component["adherence"]["level"] != "not-evaluated"
+            component["adherence"]["level"] != ""
           ) {
             components.push(component);
           }
@@ -58,7 +58,7 @@ export function getEvaluatedChapterCriteriaComponents(evaluation) {
             if (
               component["adherence"] &&
               component["adherence"]["level"] &&
-              component["adherence"]["level"] != "not-evaluated"
+              component["adherence"]["level"] != ""
             ) {
               components.push(component);
             }

--- a/src/utils/importEvaluation.js
+++ b/src/utils/importEvaluation.js
@@ -66,7 +66,7 @@ export function importEvaluation(event) {
                   currentEvaluationCriteria["components"].push({
                     name: component,
                     adherence: {
-                      level: "not-evaluated",
+                      level: "",
                       notes: "",
                     },
                   });
@@ -78,7 +78,7 @@ export function importEvaluation(event) {
                 components.push({
                   name: component,
                   adherence: {
-                    level: "not-evaluated",
+                    level: "",
                     notes: "",
                   },
                 });


### PR DESCRIPTION
Fixes https://github.com/GSA/openacr/issues/246 and fixes https://github.com/GSA/openacr/issues/260

**New report QA**

1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Click 'Start new report' or 'New report'.
3. Switch to the different table/chapter pages.
4. Adjust the level from '- Select -' to any other value or vice-versa.
5. Confirm you see the progress bar increment or decrement when you do that.
6. Click the 'View report' or 'Report' tab.
7. Confirm you see a 'Valid' message.
8. Confirm in the report you see the level is correctly matching the values you have set and if the value is '- Select -' (essentially none) then you should not see the component.

**Existing report QA**

1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Click 'Start new report' or 'New report'.
3. Click 'Open report'.
4. Upload a yaml file from OpenACR. Try the 'drupal-9.yaml' or any of the yaml files from https://github.com/GSA/openacr/tree/main/openacr.
5. Switch to the different table/chapter pages.
6. Adjust the level from '- Select -' to any other value or vice-versa.
7. Confirm you see the progress bar increment or decrement when you do that.
8. Click the 'View report' or 'Report' tab.
9. Confirm you see a 'Valid' message.
10. Confirm in the report you see the level is correctly matching the values you have set and if the value is '- Select -' (essentially none) then you should not see the component.

**Sidebar QA**

1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Switch to the different table/chapter pages.
3. Confirm the progress bars show as one column instead of two.