### PR TITLE
About expanded by default, notes label change and fixed bug

### DIFF
--- a/cypress/integration/about.test.js
+++ b/cypress/integration/about.test.js
@@ -8,7 +8,6 @@ describe("About", () => {
       },
     });
     cy.get("@consoleError").should("not.be.called");
-    cy.get("button").contains("+ Expand All Sections").click();
   });
 
   it("enter product name and see it reflected in the sidebar", () => {

--- a/cypress/integration/accordion.test.js
+++ b/cypress/integration/accordion.test.js
@@ -6,7 +6,6 @@ describe("Accordions", () => {
 
     cy.visit("/about#author-editor");
     cy.focused()
-      .click()
       .get(authorNameField)
       .should("be.visible")
       .focused()
@@ -15,18 +14,17 @@ describe("Accordions", () => {
       .should("not.be.visible");
   });
 
-  it("can all be expanded and collapsed", () => {
+  it("can all be collapsed and expanded", () => {
     cy.visit("/about");
-    cy.get("button")
-      .contains("+ Expand All Sections")
-      .click()
-      .get("details")
-      .should("have.attr", "open");
-
     cy.get("button")
       .contains("− Collapse All Sections")
       .click()
       .get("details")
       .should("not.have.attr", "open");
+    cy.get("button")
+      .contains("+ Expand All Sections")
+      .click()
+      .get("details")
+      .should("have.attr", "open");
   });
 });

--- a/cypress/integration/report.test.js
+++ b/cypress/integration/report.test.js
@@ -24,7 +24,6 @@ describe("Report", () => {
 
   it("should show entered name and version", () => {
     cy.visit("/about");
-    cy.get("button").contains("+ Expand All Sections").click();
     cy.get("#evaluation-product-name").type("Drupal");
     cy.get("#evaluation-product-version").type("9.1");
 
@@ -57,7 +56,6 @@ describe("Report", () => {
 
   it("should show entered report date", () => {
     cy.visit("/about");
-    cy.get("button").contains("+ Expand All Sections").click();
     cy.get("#evaluation-report-date").clear().type("12/31/2021");
 
     cy.get("button").contains("View Report").click();
@@ -69,7 +67,6 @@ describe("Report", () => {
 
   it("should show selected license", () => {
     cy.visit("/about");
-    cy.get("button").contains("+ Expand All Sections").click();
     cy.get("#evaluation-license")
       .type("creative commons")
       .get(".listContainer")
@@ -90,7 +87,6 @@ describe("Report", () => {
 
   it("should not show license header when license is cleared", () => {
     cy.visit("/about");
-    cy.get("button").contains("+ Expand All Sections").click();
     cy.get(".clearSelect").click();
 
     cy.get("button").contains("View Report").click();
@@ -102,7 +98,6 @@ describe("Report", () => {
 
   it("should show entered related OpenACR", () => {
     cy.visit("/about");
-    cy.get("button").contains("+ Expand All Sections").click();
 
     cy.get("button")
       .contains("Add related OpenACR")

--- a/cypress/integration/report.test.js
+++ b/cypress/integration/report.test.js
@@ -119,7 +119,7 @@ describe("Report", () => {
     );
   });
 
-  it("should show entered level and notes for component", () => {
+  it("should show entered level and notes for a criteria", () => {
     cy.visit("/chapter/success_criteria_level_a");
     cy.get("button").contains("+ Expand All Sections").click();
 
@@ -137,7 +137,7 @@ describe("Report", () => {
       .should("contain", "Web: Does support non-text content.");
   });
 
-  it("should render markdown in notes for component", () => {
+  it("should render markdown in notes columns for a criteria", () => {
     cy.visit("/chapter/success_criteria_level_a");
     cy.get("button").contains("+ Expand All Sections").click();
 

--- a/cypress/integration/report.test.js
+++ b/cypress/integration/report.test.js
@@ -136,4 +136,23 @@ describe("Report", () => {
       .should("contain", "Web: Supports")
       .should("contain", "Web: Does support non-text content.");
   });
+
+  it("should render markdown in notes for component", () => {
+    cy.visit("/chapter/success_criteria_level_a");
+    cy.get("button").contains("+ Expand All Sections").click();
+
+    cy.get("textarea[id='evaluation-1.1.1-web-notes']").clear();
+
+    cy.get("textarea[id='evaluation-1.1.1-web-notes']").type(
+      "[Drupal 8](https://www.drupal.org/) requires alt text for images by default."
+    );
+
+    cy.get("a[href='/report#text-equiv-all-editor']").click();
+
+    cy.get(
+      "#success_criteria_level_a-editor + table tbody tr td:nth-child(3) a"
+    )
+      .should("have.attr", "href")
+      .and("contains", "https://www.drupal.org/");
+  });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1664,9 +1664,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001292",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001292.tgz",
-      "integrity": "sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw==",
+      "version": "1.0.30001297",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001297.tgz",
+      "integrity": "sha512-6bbIbowYG8vFs/Lk4hU9jFt7NknGDleVAciK916tp6ft1j+D//ZwwL6LbF1wXMQ32DMSjeuUV8suhh6dlmFjcA==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -7588,9 +7588,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001292",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001292.tgz",
-      "integrity": "sha512-jnT4Tq0Q4ma+6nncYQVe7d73kmDmE9C3OGTx3MvW7lBM/eY1S1DZTMBON7dqV481RhNiS5OxD7k9JQvmDOTirw==",
+      "version": "1.0.30001297",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001297.tgz",
+      "integrity": "sha512-6bbIbowYG8vFs/Lk4hU9jFt7NknGDleVAciK916tp6ft1j+D//ZwwL6LbF1wXMQ32DMSjeuUV8suhh6dlmFjcA==",
       "dev": true
     },
     "caseless": {

--- a/src/components/Component.svelte
+++ b/src/components/Component.svelte
@@ -50,7 +50,7 @@
     </div>
 
     <div class="field">
-      <label for="evaluation-{criteria}-{component}-notes">Notes</label>
+      <label for="evaluation-{criteria}-{component}-notes">Remarks and Explanations</label>
       <textarea
         bind:value={$evaluation['chapters'][chapterId]['criteria'][currentEvaluationCriteriaIndex]['components'][currentEvaluationComponentIndex]['adherence']['notes']}
         id="evaluation-{criteria}-{component}-notes"

--- a/src/components/report/ReportChapter.svelte
+++ b/src/components/report/ReportChapter.svelte
@@ -3,6 +3,7 @@
   import { getCatalogChapter } from "../../utils/getCatalogItems.js";
   import ReportChapterTableResult from "./ReportChapterTableResult.svelte";
   import HeaderWithAnchor from "../HeaderWithAnchor.svelte";
+  import marked from 'marked';
 
   export let standard;
   export let chapterId;
@@ -38,7 +39,7 @@
 <HeaderWithAnchor id={chapterId} level=3 {download}>{chapter.label}</HeaderWithAnchor>
 
 {#if $evaluation['chapters'][chapterId]['notes']}
-  Notes: {$evaluation['chapters'][chapterId]['notes']}
+  Notes: {@html marked($evaluation['chapters'][chapterId]['notes'])}
 {/if}
 
 {#if $evaluation['chapters'][chapterId]['criteria']}

--- a/src/components/report/ReportChapterTableResult.svelte
+++ b/src/components/report/ReportChapterTableResult.svelte
@@ -1,5 +1,6 @@
 <script>
   import { catalogChapterCriteria, catalogComponentLabel, levelLabel } from "../../utils/getCatalogItems.js";
+  import marked from 'marked';
 
   export let standard;
   export let chapterId;
@@ -56,7 +57,7 @@
       <ul>
         {#each criteria.components as component}
         {#if component.adherence.notes}
-          <li>{@html catalogComponentLabel(component.name, "html")}{component.adherence.notes}</li>
+          <li>{@html catalogComponentLabel(component.name, "html")}{@html marked(component.adherence.notes)}</li>
           {/if}
         {/each}
       </ul>

--- a/src/components/report/ReportHeader.svelte
+++ b/src/components/report/ReportHeader.svelte
@@ -4,6 +4,7 @@
   import { evaluation } from "../../stores/evaluation.js";
   import catalog from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
   import { standardsIncluded } from "../../utils/getCatalogItems.js";
+  import marked from 'marked';
 
   $evaluation.title = $evaluation["product"]["name"] + " Accessibility Conformance Report";
 
@@ -21,7 +22,7 @@ Based on {catalog.title}
 
 {#if $evaluation["product"]["description"]}
   <HeaderWithAnchor id="product-description" level=2 {download}>Product Description</HeaderWithAnchor>
-  {$evaluation["product"]["description"]}
+  {@html marked($evaluation["product"]["description"])}
 {/if}
 
 <HeaderWithAnchor id="contact-information" level=2 {download}>Contact Information</HeaderWithAnchor>
@@ -50,12 +51,12 @@ Based on {catalog.title}
 
 {#if $evaluation["notes"]}
   <HeaderWithAnchor id="notes" level=2 {download}>Notes</HeaderWithAnchor>
-  {$evaluation["notes"]}
+  {@html marked($evaluation["notes"])}
 {/if}
 
 {#if $evaluation["evaluation_methods_used"]}
   <HeaderWithAnchor id="evaluation-methods" level=2 {download}>Evaluation Methods Used</HeaderWithAnchor>
-  {$evaluation["evaluation_methods_used"]}
+  {@html marked($evaluation["evaluation_methods_used"])}
 {/if}
 
 <HeaderWithAnchor id="applicable-standards-guidelines" level=2 {download}>Applicable Standards/Guidelines</HeaderWithAnchor>

--- a/src/components/report/ReportSummary.svelte
+++ b/src/components/report/ReportSummary.svelte
@@ -1,6 +1,7 @@
 <script>
   import HeaderWithAnchor from "../HeaderWithAnchor.svelte";
   import { evaluation } from "../../stores/evaluation.js";
+  import marked from 'marked';
 
   export let download = false;
 </script>
@@ -9,7 +10,7 @@
   <HeaderWithAnchor id="legal-disclaimer" level=2 {download}>
     Legal Disclaimer {#if $evaluation["vendor"]["company_name"]}({$evaluation["vendor"]["company_name"]}){/if}
   </HeaderWithAnchor>
-  {$evaluation["legal_disclaimer"]}
+  {@html marked($evaluation["legal_disclaimer"])}
 {/if}
 {#if $evaluation["repository"]}
   <HeaderWithAnchor id="repository" level=2 {download}>Repository</HeaderWithAnchor>

--- a/src/routes/About.svelte
+++ b/src/routes/About.svelte
@@ -82,7 +82,7 @@
 
 <ExpandCollapseAll />
 
-<details>
+<details open>
   <summary>
     <HeaderWithAnchor id="product" level=2>Product</HeaderWithAnchor>
   </summary>
@@ -117,7 +117,7 @@
   </div>
 </details>
 
-<details>
+<details open>
   <summary>
     <HeaderWithAnchor id="author" level=2>Author</HeaderWithAnchor>
   </summary>
@@ -183,7 +183,7 @@
   </div>
 </details>
 
-<details>
+<details open>
   <summary>
     <HeaderWithAnchor id="vendor" level=2>Vendor</HeaderWithAnchor>
   </summary>
@@ -249,7 +249,7 @@
   </div>
 </details>
 
-<details>
+<details open>
   <summary>
     <HeaderWithAnchor id="acr-report-details" level=2>ACR Report Details</HeaderWithAnchor>
   </summary>
@@ -320,7 +320,7 @@
   </div>
 </details>
 
-<details>
+<details open>
   <summary>
     <HeaderWithAnchor id="related-openacrs" level=2>Related OpenACRs</HeaderWithAnchor>
   </summary>

--- a/src/routes/Overview.svelte
+++ b/src/routes/Overview.svelte
@@ -45,7 +45,7 @@
     page lists the success criteria that you have checked and not checked.
   </li>
   <li>
-    You can export your report as YAML (structured data) but also as HTML (web page) and Markdown (simple markup). Note: You will not be able
+    You can export your report as YAML (structured data) but also as HTML (web page). Note: You will not be able
     to edit the report the future without the YAML file.
   </li>
   <li>


### PR DESCRIPTION
Fixes https://github.com/GSA/openacr/issues/262 and fixes https://github.com/GSA/openacr/issues/263

**About page QA**

1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Click 'Start new report' or 'New report'.
3. Switch to the about page.
4. Confirm all sections are expanded by default.

**Chapter pages QA**

1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Click 'Start new report' or 'New report'.
3. Switch to the different table/chapter pages.
4. Confirm the text box label is set to 'Remarks and Explanations'
5. Add some markdown in the text box 
6. Click the 'View report' or 'Report' tab.
7. Confirm you see a 'Valid' message.
8. Confirm in the report you see in the 'Remarks and Explanations' column the markdown is correctly rendered.

