### PR TITLE
275 Change Docs to Documentation in the top navigation

### DIFF
--- a/src/data/chapterNavs.js
+++ b/src/data/chapterNavs.js
@@ -5,7 +5,7 @@ const chapterNavs = {
   functional_performance_criteria: "FPC",
   hardware: "Hardware",
   software: "Software",
-  support_documentation_and_services: "Docs",
+  support_documentation_and_services: "Documentation",
 };
 
 export default chapterNavs;


### PR DESCRIPTION
Closes https://github.com/GSA/openacr/issues/275

QA
- Documentation is spelled correctly
- The 'Documentation' nav item links to  https://gsa.github.io/openacr-editor/chapter/support_documentation_and_services