### PR TITLE
Added paragraph tag to match the spacing in remarks and explanations.

### DIFF
--- a/src/components/report/ReportChapterTableResult.svelte
+++ b/src/components/report/ReportChapterTableResult.svelte
@@ -46,7 +46,7 @@
       <ul>
         {#each criteria.components as component}
           {#if component.adherence.level}
-            <li>{@html catalogComponentLabel(component.name, "html")}{levelLabel(component.adherence.level)}</li>
+            <li>{@html catalogComponentLabel(component.name, "html")}<p>{levelLabel(component.adherence.level)}</p></li>
           {/if}
         {/each}
       </ul>


### PR DESCRIPTION
Closes https://github.com/GSA/openacr/issues/276

**QA**

1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Click 'Start new report' or 'New report'.
3. Click 'Open report'.
4. Upload a yaml file from OpenACR. Try the 'drupal-9.yaml' or any of the yaml files from https://github.com/GSA/openacr/tree/main/openacr.
5. Click the 'View report' or 'Report' tab.
6. Confirm you see a 'Valid' message.
7. Confirm in the report you see the spacing for the values in the 'Conformance Level' column matches the 'Remarks and Explanations' column