### PR TITLE
Add text to README in downloadable zip

### DIFF
--- a/src/components/report/ReportZipDownload.svelte
+++ b/src/components/report/ReportZipDownload.svelte
@@ -24,7 +24,7 @@
 
   onMount(() => {
     htmlDownload = createHTMLDownload(htmlDownloadTemplate, title, "en");
-    zip.file('README.txt', '');
+    zip.file('README.txt', 'If you need to gather feedback from other people in your organization, please send the zipped file (HTML and YAML) to your collaborators. Collaborators can view the report by opening the HTML file with any web browser. If they would like to make changes to the report, they should go to OpenACR Editor and upload the YAML file to make edits to the content of the report. Do not edit the HTML file directly, it is just for viewing the report.\n\nIf your report is final and you\'re ready to submit the report to an agency in response to an Request for Proposal (RFP), please attach the YAML file to your proposal.');
     zip.file(`${filename}.html`, htmlDownload);
     zip.file(`${filename}.yaml`, yaml.dump($evaluation));
     zip.generateAsync({type:"base64"}).then(function (base64) {


### PR DESCRIPTION
Closes https://github.com/GSA/openacr/issues/273

## QA
-     After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
-     Click 'Open report'.
-     Upload a yaml file from OpenACR. Try the 'drupal-9.yaml' or any of the yaml files from https://github.com/GSA/openacr/tree/main/openacr.
-     Click the 'View report' or 'Report' tab.
-     Confirm you see a 'Valid' message.
-     Click 'Download Report (YAML & HTML)
-     Confirm in the downloaded .zip file that the README exists and includes user instructions.