### PR TITLE
Download accordion and bug fix

### DIFF
--- a/cypress/integration/accordion.test.js
+++ b/cypress/integration/accordion.test.js
@@ -1,15 +1,22 @@
 /// <reference types="Cypress" />
 
 describe("Accordions", () => {
-  it("clicking anchor link, opens accordion", () => {
+  it("clicking anchor link, opens accordion, collapse all is still enabled", () => {
     cy.visit("/chapter/success_criteria_level_a");
     cy.get(
       '.chapter-help-text a[href="#1.1.1-electronic-docs-editor"]'
     ).click();
     cy.get('[id="1.1.1-electronic-docs-editor"]').should("be.visible");
+    cy.get("button.collapse").should("not.be.disabled");
   });
 
-  it("can be expanded and collapsed", () => {
+  it("visiting URL with anchor, accordion is open, collapse all is still enabled", () => {
+    cy.visit("/chapter/success_criteria_level_a#1.1.1-web-editor");
+    cy.get('[id="1.1.1-web-editor"]').should("be.visible");
+    cy.get("button.collapse").should("not.be.disabled");
+  });
+
+  it("visiting URL with anchor, collapse accordion, expand all is still enabled", () => {
     cy.visit("/about#author-editor");
     cy.focused()
       .parent()
@@ -20,19 +27,15 @@ describe("Accordions", () => {
       .parent()
       .parent()
       .should("not.have.attr", "open");
+    cy.get("button.expand").should("not.be.disabled");
   });
 
   it("can all be collapsed and expanded", () => {
     cy.visit("/about");
-    cy.get("button")
-      .contains("− Collapse All Sections")
+    cy.get("button.collapse")
       .click()
       .get("details")
       .should("not.have.attr", "open");
-    cy.get("button")
-      .contains("+ Expand All Sections")
-      .click()
-      .get("details")
-      .should("have.attr", "open");
+    cy.get("button.expand").click().get("details").should("have.attr", "open");
   });
 });

--- a/cypress/integration/accordion.test.js
+++ b/cypress/integration/accordion.test.js
@@ -36,6 +36,8 @@ describe("Accordions", () => {
       .click()
       .get("details")
       .should("not.have.attr", "open");
+    cy.get("button.collapse").should("is.disabled");
     cy.get("button.expand").click().get("details").should("have.attr", "open");
+    cy.get("button.expand").should("is.disabled");
   });
 });

--- a/cypress/integration/accordion.test.js
+++ b/cypress/integration/accordion.test.js
@@ -36,8 +36,8 @@ describe("Accordions", () => {
       .click()
       .get("details")
       .should("not.have.attr", "open");
-    cy.get("button.collapse").should("is.disabled");
+    cy.get("button.collapse").should("be.disabled");
     cy.get("button.expand").click().get("details").should("have.attr", "open");
-    cy.get("button.expand").should("is.disabled");
+    cy.get("button.expand").should("be.disabled");
   });
 });

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -65,6 +65,7 @@
     {/each}
     <NavItem to="/report">Report</NavItem>
     <NavItem to="/glossary">Glossary</NavItem>
+    <NavItem to="/acknowledgements">Acknowledgements</NavItem>
   </Nav>
   <section
     id="content"

--- a/src/components/ExpandCollapseAll.svelte
+++ b/src/components/ExpandCollapseAll.svelte
@@ -23,10 +23,10 @@
   };
 
   let initButtonStatus = function() {
-    let triggers = document.querySelectorAll("details summary");
+    let details = document.querySelectorAll("details");
 
-    for (var i = 0, length = triggers.length; i < length; i++) {
-      triggers[i].addEventListener("click", function() {
+    for (var i = 0, length = details.length; i < length; i++) {
+      details[i].addEventListener("toggle", function() {
         setTimeout(setButtonStatus, 100);
       });
     }

--- a/src/components/HeaderWithAnchor.svelte
+++ b/src/components/HeaderWithAnchor.svelte
@@ -37,7 +37,7 @@
       position:relative;
       opacity: 1;
       left: 0;
-      vertical-align: top
+      vertical-align: top;
     }
   }
   a.header-anchor {
@@ -54,7 +54,10 @@
   a.header-anchor:focus,a.header-anchor:hover {
     text-decoration: underline;
     font-size: large;
-    opacity: 1
+    opacity: 1;
+  }
+  summary>h3:first-child:before {
+    line-height: 1.2;
   }
 </style>
 

--- a/src/index.html
+++ b/src/index.html
@@ -226,15 +226,6 @@
         <p><strong>Date:</strong> Published December 2021.</p>
         <p><strong>Version:</strong> v0.1.0</p>
         <p>
-          <strong>GSA</strong>: Syed Azeem, Karl Hebenstreit, Joseph Novak,
-          Charles Popelka, Richard Speidel, Sean Zerges.
-          <strong>CivicActions</strong>: Owen Barton, Danita Delce, Mike
-          Gifford, Marlena Medford, Daniel Mundra, Farooq Zakhilwal.
-          <strong>Contributors</strong>:
-          <a href="{{{ pathPrefix }}}/acknowledgements">Acknowledgements</a>
-          lists additional contributors.
-        </p>
-        <p>
           <a href="https://github.com/GSA/openacr">OpenACR</a>
           is a format maintained by the
           <a href="https://gsa.gov/"

--- a/src/routes/Acknowledgements.svelte
+++ b/src/routes/Acknowledgements.svelte
@@ -27,8 +27,8 @@
 
 <HeaderWithAnchor id="project-team" level=2>Project Team</HeaderWithAnchor>
 <ul>
-  <li><strong>GSA</strong>: Syed Azeem, Karl Hebenstreit, Joseph Novak, Charles Popelka, Richard Speidel, Sean Zerges.</li>
-  <li><strong>CivicActions</strong>: Owen Barton, Danita Delce, Mike Gifford, Marlena Medford, Daniel Mundra, Farooq Zakhilwal.</li>
+  <li><strong>GSA</strong>: Syed Azeem, Karl Hebenstreit, Andrew Neilson, Joseph Novak, Charles Popelka, Richard Speidel, Sean Zerges.</li>
+  <li><strong>CivicActions</strong>: Owen Barton, Melinda Burgess, Danita Delce, Mike Gifford, Marlena Medford, Daniel Mundra, Jacqueline Quintanilla, Farooq Zakhilwal.</li>
 </ul>
 
 <HeaderWithAnchor id="major-contributors" level=2>Major Contributors</HeaderWithAnchor>

--- a/src/routes/Report.svelte
+++ b/src/routes/Report.svelte
@@ -37,14 +37,20 @@
   <ReportYAMLDownload />
 </p>
 
-<p>Some agencies and corporations have a policy prohibiting the the download .of zip files. <strong>If you cannot download the .zip file</strong> you can download the YAML file by clicking the link above and save the HTML file convenient viewing by:</p>
+<details>
+  <summary>
+    <HeaderWithAnchor id="download-help" level=3>Have trouble downloading .zip files?</HeaderWithAnchor>
+  </summary>
 
-<ol>
-  <li>Right click anywhere on this page and select Save As.</li>
-  <li>Choose a location where you want to save your HTML file.</li>
-  <li>Share the HTML file or folder and the YAML file you previously downloaded with your collaborators.</li>
-  <li>Let your collaborators know that they can view the HTML version of the file and can make edits by going to the OpenACR editor and uploading the YAML file. When they have completed their edits, they must to send you the YAML file. The HTML file is optional.</li>
-</ol>
+  <p>Some agencies and corporations have a policy prohibiting the the download .of zip files. <strong>If you cannot download the .zip file</strong> you can download the YAML file by clicking the link above and save the HTML file convenient viewing by:</p>
+
+  <ol>
+    <li>Right click anywhere on this page and select Save As.</li>
+    <li>Choose a location where you want to save your HTML file.</li>
+    <li>Share the HTML file or folder and the YAML file you previously downloaded with your collaborators.</li>
+    <li>Let your collaborators know that they can view the HTML version of the file and can make edits by going to the OpenACR editor and uploading the YAML file. When they have completed their edits, they must to send you the YAML file. The HTML file is optional.</li>
+  </ol>
+</details>
 
 <ReportValid />
 <ReportHeader />

--- a/src/utils/honourFragmentIdLinks.js
+++ b/src/utils/honourFragmentIdLinks.js
@@ -6,7 +6,7 @@ export function honourFragmentIdLinks(routerLocation) {
 
     // if inside a collapsed section, open it.
     if (fragment.parentElement.nodeName === "DETAILS") {
-      fragment.parentElement.setAttribute("open", true);
+      fragment.parentElement.setAttribute("open", "");
     }
 
     // explicitly move focus


### PR DESCRIPTION
Fixes https://github.com/GSA/openacr/issues/296 and closes https://github.com/GSA/openacr/issues/298

Summary of changes:
- Moved acknowledgments link from the footer to nav menu. Removed names from footer. Added missing names.
- Moved download instructions into `<details>` and adjusted CSS for that.
- Updated logic for expand/collapse all to handle cases where we toggle that with anchors. Added tests for that.

**Download text QA**

1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Click the 'View report' or 'Report' tab.
3. Confirm below the download button the help text is in an accordion. Expand it to reveal the text.

**Accordion QA**

Note: Test in multiple browsers and please comment re: which browsers tested.

1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. For A and AA, test the links in the chapter help text. Confirm that if a link is clicked, the first accordion on the page opens.
3. Confirm that 'collapse all' is not disabled (no strikethrough) and clicking it collapses all accordions.
4. Click 'expand all' to expand all accordions, close one manually, and confirm that 'expand all' is not disabled (no strikethrough) and clicking it expands all accordions.
 