### PR TITLE
Sanitizing markdown/html output on report

### DIFF
--- a/cypress/integration/report.test.js
+++ b/cypress/integration/report.test.js
@@ -150,6 +150,39 @@ describe("Report", () => {
       .and("contains", "https://www.drupal.org/");
   });
 
+  it("should sanitize XSS example in notes for a chapter", () => {
+    cy.visit("/chapter/success_criteria_level_aa");
+
+    cy.get("textarea[id='evaluation-chapter-notes']").clear();
+
+    cy.get("textarea[id='evaluation-chapter-notes']").type(
+      "<b onclick=\"alert('Woof!')\">click me!</b>"
+    );
+
+    cy.get("button").contains("View Report").click();
+
+    cy.get("#success_criteria_level_aa-editor + p b").should(
+      "not.have.attr",
+      "onclick"
+    );
+  });
+
+  it("should render HTML in notes for a chapter", () => {
+    cy.visit("/chapter/success_criteria_level_aaa");
+
+    cy.get("textarea[id='evaluation-chapter-notes']").clear();
+
+    cy.get("textarea[id='evaluation-chapter-notes']").type(
+      "Where possible the <a href='https://www.drupal.org/'>Drupal</a> community strives to exceed AA compliance."
+    );
+
+    cy.get("button").contains("View Report").click();
+
+    cy.get("#success_criteria_level_aaa-editor + p a")
+      .should("have.attr", "href")
+      .and("contains", "https://www.drupal.org/");
+  });
+
   it("should not display table for disabled chapter but should for enabled chapter", () => {
     cy.visit("/chapter/hardware");
     cy.get("#evaluation-disabled-chapter-hardware").check();

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@openacr/openacr": "^0.3.3",
         "core-js": "3",
         "jszip": "^3.7.1",
-        "marked": "^0.8.2",
+        "marked": "^4.0.12",
         "svelte-navigator": "^3.0.8"
       },
       "devDependencies": {
@@ -43,6 +43,7 @@
         "rollup-plugin-svelte": "^5.0.3",
         "rollup-plugin-terser": "^5.1.3",
         "rollup-plugin-typescript": "^1.0.1",
+        "sanitize-html": "^2.6.1",
         "sirv-cli": "^0.4.4",
         "svelte": "^3.0.0",
         "svelte-select": "^4.4.6",
@@ -2434,6 +2435,15 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "node_modules/deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -3751,6 +3761,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-reference": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -4332,14 +4351,14 @@
       }
     },
     "node_modules/marked": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ==",
       "bin": {
-        "marked": "bin/marked"
+        "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 8.16.2"
+        "node": ">= 12"
       }
     },
     "node_modules/matches-selector": {
@@ -4462,6 +4481,18 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
       "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
+      "dev": true,
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -4825,6 +4856,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE=",
+      "dev": true
+    },
     "node_modules/parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -4885,6 +4922,12 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
+    "node_modules/picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "node_modules/picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -4934,6 +4977,24 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.4.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.6.tgz",
+      "integrity": "sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==",
+      "dev": true,
+      "dependencies": {
+        "nanoid": "^3.2.0",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/prelude-ls": {
@@ -5543,6 +5604,32 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "node_modules/sanitize-html": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.6.1.tgz",
+      "integrity": "sha512-DzjSz3H5qDntD7s1TcWCSoRPmNR8UmA+y+xZQOvWgjATe2Br9ZW73+vD3Pj6Snrg0RuEuJdXgrKvnYuiuixRkA==",
+      "dev": true,
+      "dependencies": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^6.0.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      }
+    },
+    "node_modules/sanitize-html/node_modules/escape-string-regexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -5654,6 +5741,15 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
@@ -8510,6 +8606,12 @@
       "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
       "dev": true
     },
+    "deepmerge": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
+      "dev": true
+    },
     "define-properties": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
@@ -9506,6 +9608,12 @@
       "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
       "dev": true
     },
+    "is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true
+    },
     "is-reference": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -9961,9 +10069,9 @@
       }
     },
     "marked": {
-      "version": "0.8.2",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
-      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw=="
+      "version": "4.0.12",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.12.tgz",
+      "integrity": "sha512-hgibXWrEDNBWgGiK18j/4lkS6ihTe9sxtV4Q1OQppb/0zzyPSzoFANBa5MfsG/zgsWklmNnhm0XACZOH/0HBiQ=="
     },
     "matches-selector": {
       "version": "1.2.0",
@@ -10054,6 +10162,12 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
       "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
+      "dev": true
+    },
+    "nanoid": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
+      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
       "dev": true
     },
     "natural-compare": {
@@ -10326,6 +10440,12 @@
         "callsites": "^3.0.0"
       }
     },
+    "parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE=",
+      "dev": true
+    },
     "parse5": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/parse5/-/parse5-6.0.1.tgz",
@@ -10377,6 +10497,12 @@
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
       "dev": true
     },
+    "picocolors": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
+      "dev": true
+    },
     "picomatch": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
@@ -10411,6 +10537,17 @@
       "dev": true,
       "requires": {
         "find-up": "^4.0.0"
+      }
+    },
+    "postcss": {
+      "version": "8.4.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.6.tgz",
+      "integrity": "sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==",
+      "dev": true,
+      "requires": {
+        "nanoid": "^3.2.0",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
       }
     },
     "prelude-ls": {
@@ -10900,6 +11037,28 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "sanitize-html": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.6.1.tgz",
+      "integrity": "sha512-DzjSz3H5qDntD7s1TcWCSoRPmNR8UmA+y+xZQOvWgjATe2Br9ZW73+vD3Pj6Snrg0RuEuJdXgrKvnYuiuixRkA==",
+      "dev": true,
+      "requires": {
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^6.0.0",
+        "is-plain-object": "^5.0.0",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
+          "dev": true
+        }
+      }
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -10986,6 +11145,12 @@
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
+      "dev": true
+    },
+    "source-map-js": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
       "dev": true
     },
     "source-map-support": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "core-js": "3",
         "jszip": "^3.7.1",
         "marked": "^4.0.12",
+        "sanitize-html": "^2.7.0",
         "svelte-navigator": "^3.0.8"
       },
       "devDependencies": {
@@ -43,7 +44,6 @@
         "rollup-plugin-svelte": "^5.0.3",
         "rollup-plugin-terser": "^5.1.3",
         "rollup-plugin-typescript": "^1.0.1",
-        "sanitize-html": "^2.6.1",
         "sirv-cli": "^0.4.4",
         "svelte": "^3.0.0",
         "svelte-select": "^4.4.6",
@@ -2439,7 +2439,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
       "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2487,7 +2486,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
       "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
-      "dev": true,
       "dependencies": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
@@ -2501,7 +2499,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
       "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2513,7 +2510,6 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
       "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
-      "dev": true,
       "dependencies": {
         "domelementtype": "^2.2.0"
       },
@@ -2533,7 +2529,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
       "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "dev": true,
       "dependencies": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -2591,7 +2586,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
       "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
       }
@@ -3397,7 +3391,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
       "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-      "dev": true,
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -3765,7 +3758,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
       "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -4486,7 +4478,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
       "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
-      "dev": true,
       "bin": {
         "nanoid": "bin/nanoid.cjs"
       },
@@ -4859,8 +4850,7 @@
     "node_modules/parse-srcset": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE=",
-      "dev": true
+      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
     },
     "node_modules/parse5": {
       "version": "6.0.1",
@@ -4925,8 +4915,7 @@
     "node_modules/picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "node_modules/picomatch": {
       "version": "2.2.2",
@@ -4983,7 +4972,6 @@
       "version": "8.4.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.6.tgz",
       "integrity": "sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==",
-      "dev": true,
       "dependencies": {
         "nanoid": "^3.2.0",
         "picocolors": "^1.0.0",
@@ -5605,10 +5593,9 @@
       "dev": true
     },
     "node_modules/sanitize-html": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.6.1.tgz",
-      "integrity": "sha512-DzjSz3H5qDntD7s1TcWCSoRPmNR8UmA+y+xZQOvWgjATe2Br9ZW73+vD3Pj6Snrg0RuEuJdXgrKvnYuiuixRkA==",
-      "dev": true,
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.7.0.tgz",
+      "integrity": "sha512-jfQelabOn5voO7FAfnQF7v+jsA6z9zC/O4ec0z3E35XPEtHYJT/OdUziVWlKW4irCr2kXaQAyXTXDHWAibg1tA==",
       "dependencies": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
@@ -5622,7 +5609,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -5750,7 +5736,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8609,8 +8594,7 @@
     "deepmerge": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.2.2.tgz",
-      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==",
-      "dev": true
+      "integrity": "sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg=="
     },
     "define-properties": {
       "version": "1.1.3",
@@ -8646,7 +8630,6 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.3.2.tgz",
       "integrity": "sha512-5c54Bk5Dw4qAxNOI1pFEizPSjVsx5+bpJKmL2kPn8JhBUq2q09tTCa3mjijun2NfK78NMouDYNMBkOrPZiS+ig==",
-      "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.2.0",
@@ -8656,14 +8639,12 @@
     "domelementtype": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.2.0.tgz",
-      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A==",
-      "dev": true
+      "integrity": "sha512-DtBMo82pv1dFtUmHyr48beiuq792Sxohr+8Hm9zoxklYPfa6n0Z3Byjj2IV7bmr2IyqClnqEQhfgHJJ5QF0R5A=="
     },
     "domhandler": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.2.2.tgz",
       "integrity": "sha512-PzE9aBMsdZO8TK4BnuJwH0QT41wgMbRzuZrHUcpYncEjmQazq8QEaBWgLG7ZyC/DAZKEgglpIA6j4Qn/HmxS3w==",
-      "dev": true,
       "requires": {
         "domelementtype": "^2.2.0"
       }
@@ -8677,7 +8658,6 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.8.0.tgz",
       "integrity": "sha512-w96Cjofp72M5IIhpjgobBimYEfoPjx1Vx0BSX9P30WBdZW2WIKU0T1Bd0kz2eNZ9ikjKgHbEyKx8BB6H1L3h3A==",
-      "dev": true,
       "requires": {
         "dom-serializer": "^1.0.1",
         "domelementtype": "^2.2.0",
@@ -8725,8 +8705,7 @@
     "entities": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A==",
-      "dev": true
+      "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
     },
     "envinfo": {
       "version": "7.8.1",
@@ -9341,7 +9320,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-6.1.0.tgz",
       "integrity": "sha512-gyyPk6rgonLFEDGoeRgQNaEUvdJ4ktTmmUh/h2t7s+M8oPpIPxgNACWa+6ESR57kXstwqPiCut0V8NRpcwgU7A==",
-      "dev": true,
       "requires": {
         "domelementtype": "^2.0.1",
         "domhandler": "^4.0.0",
@@ -9611,8 +9589,7 @@
     "is-plain-object": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
-      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-      "dev": true
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
     },
     "is-reference": {
       "version": "1.2.1",
@@ -10167,8 +10144,7 @@
     "nanoid": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.2.0.tgz",
-      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==",
-      "dev": true
+      "integrity": "sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA=="
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -10443,8 +10419,7 @@
     "parse-srcset": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
-      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE=",
-      "dev": true
+      "integrity": "sha1-8r0iH2zJcKk42IVWq8WJyqqiveE="
     },
     "parse5": {
       "version": "6.0.1",
@@ -10500,8 +10475,7 @@
     "picocolors": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==",
-      "dev": true
+      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
     },
     "picomatch": {
       "version": "2.2.2",
@@ -10543,7 +10517,6 @@
       "version": "8.4.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.6.tgz",
       "integrity": "sha512-OovjwIzs9Te46vlEx7+uXB0PLijpwjXGKXjVGGPIGubGpq7uh5Xgf6D6FiJ/SzJMBosHDp6a2hiXOS97iBXcaA==",
-      "dev": true,
       "requires": {
         "nanoid": "^3.2.0",
         "picocolors": "^1.0.0",
@@ -11038,10 +11011,9 @@
       "dev": true
     },
     "sanitize-html": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.6.1.tgz",
-      "integrity": "sha512-DzjSz3H5qDntD7s1TcWCSoRPmNR8UmA+y+xZQOvWgjATe2Br9ZW73+vD3Pj6Snrg0RuEuJdXgrKvnYuiuixRkA==",
-      "dev": true,
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.7.0.tgz",
+      "integrity": "sha512-jfQelabOn5voO7FAfnQF7v+jsA6z9zC/O4ec0z3E35XPEtHYJT/OdUziVWlKW4irCr2kXaQAyXTXDHWAibg1tA==",
       "requires": {
         "deepmerge": "^4.2.2",
         "escape-string-regexp": "^4.0.0",
@@ -11054,8 +11026,7 @@
         "escape-string-regexp": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-          "dev": true
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
         }
       }
     },
@@ -11150,8 +11121,7 @@
     "source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
-      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==",
-      "dev": true
+      "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
     },
     "source-map-support": {
       "version": "0.5.19",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "rollup-plugin-svelte": "^5.0.3",
     "rollup-plugin-terser": "^5.1.3",
     "rollup-plugin-typescript": "^1.0.1",
-    "sanitize-html": "^2.6.1",
     "sirv-cli": "^0.4.4",
     "svelte": "^3.0.0",
     "svelte-select": "^4.4.6",
@@ -44,6 +43,7 @@
     "core-js": "3",
     "jszip": "^3.7.1",
     "marked": "^4.0.12",
+    "sanitize-html": "^2.7.0",
     "svelte-navigator": "^3.0.8"
   },
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "rollup-plugin-svelte": "^5.0.3",
     "rollup-plugin-terser": "^5.1.3",
     "rollup-plugin-typescript": "^1.0.1",
+    "sanitize-html": "^2.6.1",
     "sirv-cli": "^0.4.4",
     "svelte": "^3.0.0",
     "svelte-select": "^4.4.6",
@@ -42,7 +43,7 @@
     "@openacr/openacr": "^0.3.3",
     "core-js": "3",
     "jszip": "^3.7.1",
-    "marked": "^0.8.2",
+    "marked": "^4.0.12",
     "svelte-navigator": "^3.0.8"
   },
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -56,6 +56,7 @@ export default {
         "node_modules/@babel/**",
         "node_modules/core-js/**",
         "node_modules/@openacr/**",
+        "node_modules/marked/**",
       ],
       presets: [
         [

--- a/src/components/report/ReportChapter.svelte
+++ b/src/components/report/ReportChapter.svelte
@@ -3,7 +3,7 @@
   import { getCatalogChapter } from "../../utils/getCatalogItems.js";
   import ReportChapterTableResult from "./ReportChapterTableResult.svelte";
   import HeaderWithAnchor from "../HeaderWithAnchor.svelte";
-  import marked from 'marked';
+  import { sanitizeMarkdown } from "../../utils/sanitizeMarkdown.js";
 
   export let standard;
   export let chapterId;
@@ -39,7 +39,7 @@
 <HeaderWithAnchor id={chapterId} level=3 {download}>{chapter.label}</HeaderWithAnchor>
 
 {#if $evaluation['chapters'][chapterId]['notes']}
-  Notes: {@html marked($evaluation['chapters'][chapterId]['notes'])}
+  Notes: {@html sanitizeMarkdown($evaluation['chapters'][chapterId]['notes'])}
 {/if}
 
 {#if $evaluation['chapters'][chapterId]['criteria'] && !$evaluation['chapters'][chapterId]['disabled'] }

--- a/src/components/report/ReportChapterTableResult.svelte
+++ b/src/components/report/ReportChapterTableResult.svelte
@@ -1,6 +1,7 @@
 <script>
   import { catalogChapterCriteria, catalogComponentLabel, levelLabel } from "../../utils/getCatalogItems.js";
   import { sanitizeMarkdown } from "../../utils/sanitizeMarkdown.js";
+  import sanitizeHtml from "sanitize-html";
 
   export let standard;
   export let chapterId;
@@ -46,7 +47,7 @@
       <ul>
         {#each criteria.components as component}
           {#if component.adherence.level}
-            <li>{@html catalogComponentLabel(component.name, "html")}<p>{levelLabel(component.adherence.level)}</p></li>
+            <li>{@html sanitizeHtml(catalogComponentLabel(component.name, "html"))}<p>{levelLabel(component.adherence.level)}</p></li>
           {/if}
         {/each}
       </ul>
@@ -57,7 +58,7 @@
       <ul>
         {#each criteria.components as component}
         {#if component.adherence.notes}
-          <li>{@html catalogComponentLabel(component.name, "html")}{@html sanitizeMarkdown(component.adherence.notes)}</li>
+          <li>{@html sanitizeHtml(catalogComponentLabel(component.name, "html"))}{@html sanitizeMarkdown(component.adherence.notes)}</li>
           {/if}
         {/each}
       </ul>

--- a/src/components/report/ReportChapterTableResult.svelte
+++ b/src/components/report/ReportChapterTableResult.svelte
@@ -1,6 +1,6 @@
 <script>
   import { catalogChapterCriteria, catalogComponentLabel, levelLabel } from "../../utils/getCatalogItems.js";
-  import marked from 'marked';
+  import { sanitizeMarkdown } from "../../utils/sanitizeMarkdown.js";
 
   export let standard;
   export let chapterId;
@@ -57,7 +57,7 @@
       <ul>
         {#each criteria.components as component}
         {#if component.adherence.notes}
-          <li>{@html catalogComponentLabel(component.name, "html")}{@html marked(component.adherence.notes)}</li>
+          <li>{@html catalogComponentLabel(component.name, "html")}{@html sanitizeMarkdown(component.adherence.notes)}</li>
           {/if}
         {/each}
       </ul>

--- a/src/components/report/ReportChapterTableResult.svelte
+++ b/src/components/report/ReportChapterTableResult.svelte
@@ -1,7 +1,6 @@
 <script>
   import { catalogChapterCriteria, catalogComponentLabel, levelLabel } from "../../utils/getCatalogItems.js";
   import { sanitizeMarkdown } from "../../utils/sanitizeMarkdown.js";
-  import sanitizeHtml from "sanitize-html";
 
   export let standard;
   export let chapterId;
@@ -47,7 +46,7 @@
       <ul>
         {#each criteria.components as component}
           {#if component.adherence.level}
-            <li>{@html sanitizeHtml(catalogComponentLabel(component.name, "html"))}<p>{levelLabel(component.adherence.level)}</p></li>
+            <li>{@html catalogComponentLabel(component.name, "html")}<p>{levelLabel(component.adherence.level)}</p></li>
           {/if}
         {/each}
       </ul>
@@ -58,7 +57,7 @@
       <ul>
         {#each criteria.components as component}
         {#if component.adherence.notes}
-          <li>{@html sanitizeHtml(catalogComponentLabel(component.name, "html"))}{@html sanitizeMarkdown(component.adherence.notes)}</li>
+          <li>{@html catalogComponentLabel(component.name, "html")}{@html sanitizeMarkdown(component.adherence.notes)}</li>
           {/if}
         {/each}
       </ul>

--- a/src/components/report/ReportHeader.svelte
+++ b/src/components/report/ReportHeader.svelte
@@ -4,7 +4,7 @@
   import { evaluation } from "../../stores/evaluation.js";
   import catalog from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
   import { standardsIncluded } from "../../utils/getCatalogItems.js";
-  import marked from 'marked';
+  import { sanitizeMarkdown } from "../../utils/sanitizeMarkdown.js";
 
   $evaluation.title = $evaluation["product"]["name"] + " Accessibility Conformance Report";
 
@@ -22,7 +22,7 @@ Based on {catalog.title}
 
 {#if $evaluation["product"]["description"]}
   <HeaderWithAnchor id="product-description" level=2 {download}>Product Description</HeaderWithAnchor>
-  {@html marked($evaluation["product"]["description"])}
+  {@html sanitizeMarkdown($evaluation["product"]["description"])}
 {/if}
 
 <HeaderWithAnchor id="contact-information" level=2 {download}>Contact Information</HeaderWithAnchor>
@@ -51,12 +51,12 @@ Based on {catalog.title}
 
 {#if $evaluation["notes"]}
   <HeaderWithAnchor id="notes" level=2 {download}>Notes</HeaderWithAnchor>
-  {@html marked($evaluation["notes"])}
+  {@html sanitizeMarkdown($evaluation["notes"])}
 {/if}
 
 {#if $evaluation["evaluation_methods_used"]}
   <HeaderWithAnchor id="evaluation-methods" level=2 {download}>Evaluation Methods Used</HeaderWithAnchor>
-  {@html marked($evaluation["evaluation_methods_used"])}
+  {@html sanitizeMarkdown($evaluation["evaluation_methods_used"])}
 {/if}
 
 <HeaderWithAnchor id="applicable-standards-guidelines" level=2 {download}>Applicable Standards/Guidelines</HeaderWithAnchor>

--- a/src/components/report/ReportLicense.svelte
+++ b/src/components/report/ReportLicense.svelte
@@ -2,6 +2,8 @@
   import { evaluation } from "../../stores/evaluation.js";
   import { validate } from "../../utils/validate.js";
   import { license } from "../../utils/license.js";
+  import sanitizeHtml from "sanitize-html";
+
   let licenseOutput;
   const valid = validate($evaluation);
 
@@ -11,5 +13,5 @@
 </script>
 
 {#if licenseOutput}
-This content is licensed under a {@html licenseOutput}.
+This content is licensed under a {@html sanitizeHtml(licenseOutput)}.
 {/if}

--- a/src/components/report/ReportLicense.svelte
+++ b/src/components/report/ReportLicense.svelte
@@ -2,7 +2,6 @@
   import { evaluation } from "../../stores/evaluation.js";
   import { validate } from "../../utils/validate.js";
   import { license } from "../../utils/license.js";
-  import sanitizeHtml from "sanitize-html";
 
   let licenseOutput;
   const valid = validate($evaluation);
@@ -13,5 +12,5 @@
 </script>
 
 {#if licenseOutput}
-This content is licensed under a {@html sanitizeHtml(licenseOutput)}.
+This content is licensed under a {@html licenseOutput}.
 {/if}

--- a/src/components/report/ReportSummary.svelte
+++ b/src/components/report/ReportSummary.svelte
@@ -1,7 +1,7 @@
 <script>
   import HeaderWithAnchor from "../HeaderWithAnchor.svelte";
   import { evaluation } from "../../stores/evaluation.js";
-  import marked from 'marked';
+  import { sanitizeMarkdown } from "../../utils/sanitizeMarkdown.js";
 
   export let download = false;
 </script>
@@ -10,7 +10,7 @@
   <HeaderWithAnchor id="legal-disclaimer" level=2 {download}>
     Legal Disclaimer {#if $evaluation["vendor"]["company_name"]}({$evaluation["vendor"]["company_name"]}){/if}
   </HeaderWithAnchor>
-  {@html marked($evaluation["legal_disclaimer"])}
+  {@html sanitizeMarkdown($evaluation["legal_disclaimer"])}
 {/if}
 {#if $evaluation["repository"]}
   <HeaderWithAnchor id="repository" level=2 {download}>Repository</HeaderWithAnchor>

--- a/src/components/report/ReportValid.svelte
+++ b/src/components/report/ReportValid.svelte
@@ -2,7 +2,7 @@
   import HeaderWithAnchor from "../HeaderWithAnchor.svelte";
   import { evaluation } from "../../stores/evaluation.js";
   import { validate } from "../../utils/validate.js";
-  import marked from "marked";
+  import { sanitizeMarkdown } from "../../utils/sanitizeMarkdown.js";
 
   const valid = validate($evaluation);
 </script>
@@ -16,5 +16,5 @@
 <div class="validation">
   <HeaderWithAnchor id="validation" level=2>Validation</HeaderWithAnchor>
 
-  {@html marked(valid.message)}
+  {@html sanitizeMarkdown(valid.message)}
 </div>

--- a/src/index.html
+++ b/src/index.html
@@ -236,7 +236,6 @@
             >
           </div>
         </div>
-        <div></div>
       </aside>
     </div>
     <footer

--- a/src/utils/getCatalogItems.js
+++ b/src/utils/getCatalogItems.js
@@ -1,4 +1,5 @@
 import catalog from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
+import sanitizeHtml from "sanitize-html";
 
 export function getCatalogChapter(chapterId) {
   for (const chapter of catalog.chapters) {
@@ -14,7 +15,7 @@ export function standardsIncluded(standardChapters) {
     const catalogChapter = getCatalogChapter(standardChapter);
     result.push(`<li>${catalogChapter.label}</li>`);
   }
-  return `<ul>${result.join("")}</ul>`;
+  return sanitizeHtml(`<ul>${result.join("")}</ul>`);
 }
 
 export function catalogChapterCriteria(chapterId, criteriaNum) {
@@ -32,7 +33,7 @@ export function catalogComponentLabel(componentId, templateType) {
       if (component.id === componentId) {
         if (component.label != "") {
           if (templateType === "html") {
-            return `<strong>${component.label}</strong>: `;
+            return sanitizeHtml(`<strong>${component.label}</strong>: `);
           } else {
             return `**${component.label}**: `;
           }

--- a/src/utils/license.js
+++ b/src/utils/license.js
@@ -1,13 +1,14 @@
 import spdxLicenseList from "spdx-license-list";
+import sanitizeHtml from "sanitize-html";
 
 export function license(evaluation, templateType) {
   if (evaluation.license) {
     if (templateType === "html") {
-      return `<a href="${
-        spdxLicenseList[evaluation.license].url
-      }" target="_blank">${
-        spdxLicenseList[evaluation.license].name
-      } <span class="visuallyhidden">(opens in a new window or tab)</span></a>`;
+      return sanitizeHtml(
+        `<a href="${spdxLicenseList[evaluation.license].url}" target="_blank">${
+          spdxLicenseList[evaluation.license].name
+        } <span class="visuallyhidden">(opens in a new window or tab)</span></a>`
+      );
     } else {
       return `[${spdxLicenseList[evaluation.license].name}](${
         spdxLicenseList[evaluation.license].url

--- a/src/utils/sanitizeMarkdown.js
+++ b/src/utils/sanitizeMarkdown.js
@@ -1,0 +1,8 @@
+import marked from "marked";
+import sanitizeHtml from "sanitize-html";
+
+export function sanitizeMarkdown(text) {
+  const markdown = marked.parse(text);
+  const sanitized = sanitizeHtml(markdown);
+  return sanitized;
+}


### PR DESCRIPTION
Fixes https://github.com/GSA/openacr/issues/306

Updated the markedjs package and installed a sanitize HTML package. Combined those in a function to sanitize any markdown and HTML added to textareas. Added few tests to check for that.

**QA**

1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Click 'Start new report' or 'New report'.
3. Switch to the different table/chapter pages.
4. Add some XSS HTML in the textareas. Use https://owasp.org/www-community/attacks/xss/ or other sources for examples.
5. Click the 'View report' or 'Report' tab.
6. Confirm you see a 'Valid' message.
7. Confirm in the report you see the content but don't get an alert popup or other XSS effect.
