### PR TITLE
Added sanitize evaluation function to cleanup the notes fields before exporting to YAML

### DIFF
--- a/src/components/report/ReportYAMLDownload.svelte
+++ b/src/components/report/ReportYAMLDownload.svelte
@@ -3,12 +3,14 @@
   import yaml from "js-yaml";
   import { validate } from "../../utils/validate.js";
   import { reportFilename } from "../../utils/reportFilename.js";
+  import { sanitizeEvaluation } from "../../utils/sanitizeEvaluation.js";
 
   const filename = reportFilename($evaluation);
-  const valid = validate($evaluation);
+  const sanitizedEvaluation = sanitizeEvaluation($evaluation);
+  const valid = validate(sanitizedEvaluation);
 
   $: yamlDownload = `data:application/yaml;charset=utf-8,${encodeURIComponent(
-    yaml.dump($evaluation)
+    yaml.dump(sanitizedEvaluation)
   )}`;
 </script>
 

--- a/src/components/report/ReportZipDownload.svelte
+++ b/src/components/report/ReportZipDownload.svelte
@@ -13,9 +13,11 @@
   import { standards } from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
   import yaml from "js-yaml";
   import JSZip from "jszip";
+  import { sanitizeEvaluation } from "../../utils/sanitizeEvaluation.js";
 
   var title = $evaluation.title;
   const filename = reportFilename($evaluation);
+  const sanitizedEvaluation = sanitizeEvaluation($evaluation);
   const valid = validate($evaluation);
   let zipDownload, htmlDownload, htmlDownloadTemplate;
 
@@ -26,7 +28,7 @@
     htmlDownload = createHTMLDownload(htmlDownloadTemplate, title, "en");
     zip.file('README.txt', 'If you need to gather feedback from other people in your organization, please send the zipped file (HTML and YAML) to your collaborators. Collaborators can view the report by opening the HTML file with any web browser. If they would like to make changes to the report, they should go to OpenACR Editor and upload the YAML file to make edits to the content of the report. Do not edit the HTML file directly, it is just for viewing the report.\n\nIf your report is final and you\'re ready to submit the report to an agency in response to a Request for Proposal (RFP), please attach the YAML file to your proposal.');
     zip.file(`${filename}.html`, htmlDownload);
-    zip.file(`${filename}.yaml`, yaml.dump($evaluation));
+    zip.file(`${filename}.yaml`, yaml.dump(sanitizedEvaluation));
     zip.generateAsync({type:"base64"}).then(function (base64) {
       zipDownload = `data:application/zip;base64,${base64}`;
     });

--- a/src/utils/sanitizeEvaluation.js
+++ b/src/utils/sanitizeEvaluation.js
@@ -1,0 +1,43 @@
+import sanitizeHtml from "sanitize-html";
+import { chapters } from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
+
+export function sanitizeEvaluation(evaluation) {
+  for (const chapter of chapters) {
+    for (
+      let chapterCriteriaIndex = 0;
+      chapterCriteriaIndex <
+      evaluation["chapters"][chapter.id]["criteria"].length;
+      chapterCriteriaIndex++
+    ) {
+      for (
+        let componentIndex = 0;
+        componentIndex <
+        evaluation["chapters"][chapter.id]["criteria"][chapterCriteriaIndex][
+          "components"
+        ].length;
+        componentIndex++
+      ) {
+        evaluation["chapters"][chapter.id]["criteria"][chapterCriteriaIndex][
+          "components"
+        ][componentIndex]["adherence"]["notes"] = sanitizeHtml(
+          evaluation["chapters"][chapter.id]["criteria"][chapterCriteriaIndex][
+            "components"
+          ][componentIndex]["adherence"]["notes"]
+        );
+      }
+    }
+
+    evaluation["chapters"][chapter.id]["notes"] = sanitizeHtml(
+      evaluation["chapters"][chapter.id]["notes"]
+    );
+  }
+  evaluation["product"]["description"] = sanitizeHtml(
+    evaluation["product"]["description"]
+  );
+  evaluation["notes"] = sanitizeHtml(evaluation["notes"]);
+  evaluation["evaluation_methods_used"] = sanitizeHtml(
+    evaluation["evaluation_methods_used"]
+  );
+  evaluation["legal_disclaimer"] = sanitizeHtml(evaluation["legal_disclaimer"]);
+  return evaluation;
+}


### PR DESCRIPTION
Closes https://github.com/GSA/openacr/issues/310

**QA**

1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Click 'Start new report' or 'New report'.
3. Switch to the different table/chapter pages.
4. Add some XSS HTML in the textareas. Use https://owasp.org/www-community/attacks/xss/ or other sources for examples.
5. Click the 'View report' or 'Report' tab.
6. Confirm you see a 'Valid' message.
7. Click both download buttons.
8. Confirm the YAML files do not include the XSS code in it.