### PR TITLE
WCAG 2.1 support and switching between catalogs

### DIFF
--- a/cypress/integration/catalog.test.js
+++ b/cypress/integration/catalog.test.js
@@ -1,0 +1,71 @@
+/// <reference types="Cypress" />
+
+const catalogs = [
+  "2.4-edition-wcag-2.0-508-en",
+  "2.4-edition-wcag-2.1-en",
+  "2.4-edition-wcag-2.1-508-en",
+];
+const chapters = [
+  "success_criteria_level_a",
+  "success_criteria_level_aa",
+  "success_criteria_level_aaa",
+];
+
+describe("Catalogs", () => {
+  catalogs.forEach((catalog) => {
+    it(`select catalog ${catalog} and load WCAG chapters and report without errors`, () => {
+      cy.visit("/");
+
+      cy.get(`input[value="${catalog}"]`).check();
+
+      chapters.forEach((chapter) => {
+        cy.visit(`/chapter/${chapter}`, {
+          onBeforeLoad(win) {
+            cy.stub(win.console, "error").as("consoleError");
+          },
+        });
+        cy.get("@consoleError").should("not.be.called");
+      });
+
+      cy.visit("/report", {
+        onBeforeLoad(win) {
+          cy.stub(win.console, "error").as("consoleError");
+        },
+      });
+      cy.get("@consoleError").should("not.be.called");
+    });
+  });
+
+  it(`toggle catalog and confirm WCAG 2.1 criteria appears and disappears`, () => {
+    const wcag21Criteria = "2.1.4";
+    cy.visit("/");
+
+    cy.get(`input[value="${catalogs[1]}"]`).check();
+
+    cy.visit(`/chapter/${chapters[0]}`);
+
+    cy.get(`div[id="${wcag21Criteria}"]`).should("exist");
+
+    cy.get("button").contains("View Report").click();
+
+    cy.get("#success_criteria_level_a-editor + table tbody tr").should(
+      "contain",
+      wcag21Criteria
+    );
+
+    cy.visit("/");
+
+    cy.get(`input[value="${catalogs[0]}"]`).check();
+
+    cy.visit(`/chapter/${chapters[0]}`);
+
+    cy.get(`div[id="${wcag21Criteria}"]`).should("not.exist");
+
+    cy.get("button").contains("View Report").click();
+
+    cy.get("#success_criteria_level_a-editor + table tbody tr").should(
+      "not.contain",
+      wcag21Criteria
+    );
+  });
+});

--- a/cypress/integration/catalog.test.js
+++ b/cypress/integration/catalog.test.js
@@ -14,7 +14,7 @@ const chapters = [
 describe("Catalogs", () => {
   catalogs.forEach((catalog) => {
     it(`select catalog ${catalog} and load WCAG chapters and report without errors`, () => {
-      cy.visit("/");
+      cy.visit("/about");
 
       cy.get(`input[value="${catalog}"]`).check();
 
@@ -39,7 +39,7 @@ describe("Catalogs", () => {
   it(`toggle catalog and confirm a WCAG 2.1 criteria appears and disappears`, () => {
     const wcag21Criteria = "2.1.4";
 
-    cy.visit("/");
+    cy.visit("/about");
 
     // Switch to WCAG 2.1 catalog.
     cy.get(`input[value="${catalogs[1]}"]`).check();
@@ -55,7 +55,7 @@ describe("Catalogs", () => {
       wcag21Criteria
     );
 
-    cy.visit("/");
+    cy.visit("/about");
 
     // Switch back to WCAG 2.0 508 catalog.
     cy.get(`input[value="${catalogs[0]}"]`).check();

--- a/cypress/integration/catalog.test.js
+++ b/cypress/integration/catalog.test.js
@@ -36,10 +36,12 @@ describe("Catalogs", () => {
     });
   });
 
-  it(`toggle catalog and confirm WCAG 2.1 criteria appears and disappears`, () => {
+  it(`toggle catalog and confirm a WCAG 2.1 criteria appears and disappears`, () => {
     const wcag21Criteria = "2.1.4";
+
     cy.visit("/");
 
+    // Switch to WCAG 2.1 catalog.
     cy.get(`input[value="${catalogs[1]}"]`).check();
 
     cy.visit(`/chapter/${chapters[0]}`);
@@ -55,6 +57,7 @@ describe("Catalogs", () => {
 
     cy.visit("/");
 
+    // Switch back to WCAG 2.0 508 catalog.
     cy.get(`input[value="${catalogs[0]}"]`).check();
 
     cy.visit(`/chapter/${chapters[0]}`);

--- a/cypress/integration/import.test.js
+++ b/cypress/integration/import.test.js
@@ -174,6 +174,71 @@ describe("Import", () => {
       .should("contain", today);
   });
 
+  it(`can toggle catalog and still be valid`, () => {
+    const fileType = "application/x-yaml";
+    const yamlExample = yamlExamples[0];
+    cy.fixture(yamlExample.filename).as("yamlFixture");
+
+    cy.visit("/");
+
+    cy.on("window:alert", cy.stub().as("alerted"));
+
+    cy.get("input[type='file']").then(function ($input) {
+      const blob = Cypress.Blob.binaryStringToBlob(this.yamlFixture, fileType);
+      const file = new File([blob], yamlExample.filename, { type: fileType });
+      const list = new DataTransfer();
+
+      list.items.add(file);
+      const myFileList = list.files;
+
+      $input[0].files = myFileList;
+      $input[0].dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    cy.get("@alerted")
+      .should("have.been.calledOnce")
+      .and(
+        "have.been.calledWith",
+        `OpenACR "${yamlExample.reportname}" loaded`
+      );
+
+    // Switch to WCAG 2.1 508 catalog.
+    cy.visit("/").get(`input[value="2.4-edition-wcag-2.1-508-en"]`).check();
+
+    cy.get("@alerted")
+      .should("have.been.calledTwice")
+      .and(
+        "have.been.calledWith",
+        "OpenACR passed validation when switching catalog."
+      );
+
+    cy.get("button")
+      .contains("View Report")
+      .click()
+      .get(".usa-alert")
+      .should("contain", "Valid Report")
+      .get("#content")
+      .should("contain", "VPAT® 2.4 WCAG 2.1 and Revised Section 508 Edition");
+
+    // Switch back to WCAG 2.0 508 catalog.
+    cy.visit("/").get(`input[value="2.4-edition-wcag-2.0-508-en"]`).check();
+
+    cy.get("@alerted")
+      .should("have.been.calledThrice")
+      .and(
+        "have.been.calledWith",
+        "OpenACR passed validation when switching catalog."
+      );
+
+    cy.get("button")
+      .contains("View Report")
+      .click()
+      .get(".usa-alert")
+      .should("contain", "Valid Report")
+      .get("#content")
+      .should("contain", "VPAT® 2.4 Revised Section 508 Edition");
+  });
+
   it(`should reject invalid example`, () => {
     const fileType = "application/x-yaml";
     const yamlExample = {

--- a/cypress/integration/import.test.js
+++ b/cypress/integration/import.test.js
@@ -203,7 +203,9 @@ describe("Import", () => {
       );
 
     // Switch to WCAG 2.1 508 catalog.
-    cy.visit("/").get(`input[value="2.4-edition-wcag-2.1-508-en"]`).check();
+    cy.visit("/about")
+      .get(`input[value="2.4-edition-wcag-2.1-508-en"]`)
+      .check();
 
     cy.get("@alerted")
       .should("have.been.calledTwice")
@@ -221,7 +223,9 @@ describe("Import", () => {
       .should("contain", "VPAT® 2.4 WCAG 2.1 and Revised Section 508 Edition");
 
     // Switch back to WCAG 2.0 508 catalog.
-    cy.visit("/").get(`input[value="2.4-edition-wcag-2.0-508-en"]`).check();
+    cy.visit("/about")
+      .get(`input[value="2.4-edition-wcag-2.0-508-en"]`)
+      .check();
 
     cy.get("@alerted")
       .should("have.been.calledThrice")

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "license": "CC0-1.0",
       "dependencies": {
-        "@openacr/openacr": "^0.3.4",
+        "@openacr/openacr": "^0.3.5",
         "core-js": "3",
         "jszip": "^3.7.1",
         "marked": "^4.0.12",
@@ -1145,9 +1145,9 @@
       "dev": true
     },
     "node_modules/@openacr/openacr": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@openacr/openacr/-/openacr-0.3.4.tgz",
-      "integrity": "sha512-J1WVi5IGT8WU4ddaMaRvr/VlPmWiwH5pu8QAKF137nyuunx5tu8Lh2rKI7SAj1izZqV35zxcH0g4p4yiFjvSwQ==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@openacr/openacr/-/openacr-0.3.5.tgz",
+      "integrity": "sha512-MjtagpOr0AvwIfhTvH+D9RuXWxcyVFe4FkuNuk7rJjjjn6SXSqN5eIGSIR56zZ9djjpIt/ktuXnx5ixWARN+vw==",
       "dependencies": {
         "ajv": "^8.6.1",
         "fs-extra": "^10.0.0",
@@ -7465,9 +7465,9 @@
       "dev": true
     },
     "@openacr/openacr": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@openacr/openacr/-/openacr-0.3.4.tgz",
-      "integrity": "sha512-J1WVi5IGT8WU4ddaMaRvr/VlPmWiwH5pu8QAKF137nyuunx5tu8Lh2rKI7SAj1izZqV35zxcH0g4p4yiFjvSwQ==",
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/@openacr/openacr/-/openacr-0.3.5.tgz",
+      "integrity": "sha512-MjtagpOr0AvwIfhTvH+D9RuXWxcyVFe4FkuNuk7rJjjjn6SXSqN5eIGSIR56zZ9djjpIt/ktuXnx5ixWARN+vw==",
       "requires": {
         "ajv": "^8.6.1",
         "fs-extra": "^10.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "CC0-1.0",
       "dependencies": {
         "@openacr/openacr": "^0.3.5",
+        "compare-versions": "^4.1.3",
         "core-js": "3",
         "jszip": "^3.7.1",
         "marked": "^4.0.12",
@@ -2119,6 +2120,11 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
+    },
+    "node_modules/compare-versions": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-4.1.3.tgz",
+      "integrity": "sha512-WQfnbDcrYnGr55UwbxKiQKASnTtNnaAWVi8jZyy8NTpVAXWACSne8lMD1iaIo9AiU6mnuLvSVshCzewVuWxHUg=="
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -8237,6 +8243,11 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=",
       "dev": true
+    },
+    "compare-versions": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/compare-versions/-/compare-versions-4.1.3.tgz",
+      "integrity": "sha512-WQfnbDcrYnGr55UwbxKiQKASnTtNnaAWVi8jZyy8NTpVAXWACSne8lMD1iaIo9AiU6mnuLvSVshCzewVuWxHUg=="
     },
     "concat-map": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   "browserslist": "> 0.25%, not dead",
   "dependencies": {
     "@openacr/openacr": "^0.3.5",
+    "compare-versions": "^4.1.3",
     "core-js": "3",
     "jszip": "^3.7.1",
     "marked": "^4.0.12",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   },
   "browserslist": "> 0.25%, not dead",
   "dependencies": {
-    "@openacr/openacr": "^0.3.4",
+    "@openacr/openacr": "^0.3.5",
     "core-js": "3",
     "jszip": "^3.7.1",
     "marked": "^4.0.12",

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -12,11 +12,13 @@
   import NavItem from "./components/NavItem.svelte";
   import { currentPage } from "./stores/currentPage.js";
   import { showYourReport } from "./stores/showYourReport.js";
-  import { chapters } from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
+  import { evaluation } from "./stores/evaluation.js";
+  import { getCatalog } from "./utils/getCatalogs.js";
   import vars from "../config/__buildEnv__.json";
   export let url = "";
 
   const pagesWithYourReport = ["Overview", "About", "Evaluation"];
+  let catalog = getCatalog($evaluation.catalog);
 
   function needsYourReport(pageName) {
     return pagesWithYourReport.indexOf(pageName) > -1;
@@ -57,7 +59,7 @@
   <Nav>
     <NavItem to="/">Overview</NavItem>
     <NavItem to="/about">About</NavItem>
-    {#each chapters as chapter}
+    {#each catalog.chapters as chapter}
       <NavItem to="chapter/{chapter.id}">
         {chapter.short_label}
         <span class="visuallyhidden">: {chapter.label}</span>

--- a/src/App.svelte
+++ b/src/App.svelte
@@ -18,7 +18,6 @@
   export let url = "";
 
   const pagesWithYourReport = ["Overview", "About", "Evaluation"];
-  let catalog = getCatalog($evaluation.catalog);
 
   function needsYourReport(pageName) {
     return pagesWithYourReport.indexOf(pageName) > -1;
@@ -38,6 +37,7 @@
   function closeEditorWarning() {
     return 'Are you sure?';
   }
+  $: catalog = getCatalog($evaluation.catalog);
 </script>
 
 <style>

--- a/src/components/Chapter.svelte
+++ b/src/components/Chapter.svelte
@@ -9,13 +9,16 @@
   import PagerLink from "./PagerLink.svelte";
   import { currentPage } from "../stores/currentPage.js";
   import { honourFragmentIdLinks } from "../utils/honourFragmentIdLinks.js";
-  import { standards, chapters } from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
   import ChapterHelpText from "../components/ChapterHelpText.svelte";
   import { evaluation } from "../stores/evaluation.js";
   import ExpandCollapseAll from "../components/ExpandCollapseAll.svelte";
+  import { getCatalog } from "../utils/getCatalogs.js";
 
   export let chapterId = null;
   export let className = undefined;
+  let catalog = getCatalog($evaluation.catalog);
+  let standards = catalog.standards;
+  let chapters = catalog.chapters;
 
   const location = useLocation();
   $: currentChapter = chapters.find( ({ id }) => id === chapterId);

--- a/src/components/Component.svelte
+++ b/src/components/Component.svelte
@@ -1,12 +1,15 @@
 <script>
   import { evaluation } from "../stores/evaluation.js";
-  import { components, terms } from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
   import HelpText from "../components/HelpText.svelte";
   import HeaderWithAnchor from "./HeaderWithAnchor.svelte";
+  import { getCatalog } from "../utils/getCatalogs.js";
 
   export let chapterId;
   export let criteria;
   export let component;
+  let catalog = getCatalog($evaluation.catalog);
+  let components = catalog.components;
+  let terms = catalog.terms;
 
   $: currentComponent = components.find( ({ id }) => id === component);
   $: currentEvaluationCriteria = ($evaluation['chapters'] && $evaluation['chapters'][chapterId]['criteria']) ? $evaluation['chapters'][chapterId]['criteria'].find( ({ num }) => num === criteria) : null;

--- a/src/components/YourReport.svelte
+++ b/src/components/YourReport.svelte
@@ -9,10 +9,11 @@
   import { showYourReport } from "../stores/showYourReport.js";
   import { importEvaluation } from "../utils/importEvaluation.js";
   import { getEvaluatedChapterCriteriaComponents, getChapterCriteriaComponents, getProgressPerChapter } from "../utils/getEvaluatedItems.js";
-  import { chapters } from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
+  import { getCatalog } from "../utils/getCatalogs.js";
   import vars from "../../config/__buildEnv__.json";
 
   let fresh, box;
+  let catalog = getCatalog($evaluation.catalog);
 
   function startNew() {
     navigate(`${vars.pathPrefix}/about`, { replace: false });
@@ -156,7 +157,7 @@
       <ReportNumbers className="your-report__description" />
       <ProgressBar percentage={100 / (totalCriteria.length / evaluatedItems.length)} />
       <ul class="your-report__progress-by-principle">
-        {#each chapters as chapter}
+        {#each catalog.chapters as chapter}
           {#if !$evaluation.chapters[chapter.id].disabled}
             <YourReportProgress
               {chapter}

--- a/src/components/YourReport.svelte
+++ b/src/components/YourReport.svelte
@@ -13,7 +13,6 @@
   import vars from "../../config/__buildEnv__.json";
 
   let fresh, box;
-  let catalog = getCatalog($evaluation.catalog);
 
   function startNew() {
     navigate(`${vars.pathPrefix}/about`, { replace: false });
@@ -52,6 +51,7 @@
   $: progressPerChapter = getProgressPerChapter($evaluation);
   $: evaluatedItems = getEvaluatedChapterCriteriaComponents($evaluation);
   $: totalCriteria = getChapterCriteriaComponents($evaluation);
+  $: catalog = getCatalog($evaluation.catalog);
 </script>
 
 <style>

--- a/src/components/report/ReportChapter.svelte
+++ b/src/components/report/ReportChapter.svelte
@@ -8,8 +8,9 @@
   export let standard;
   export let chapterId;
   export let download = false;
+  let catalogName = $evaluation.catalog;
 
-  $: chapter = getCatalogChapter(chapterId);
+  $: chapter = getCatalogChapter(catalogName, chapterId);
 </script>
 
 <style>
@@ -53,7 +54,7 @@
     </thead>
     <tbody>
       {#each $evaluation['chapters'][chapterId]['criteria'] as criteria}
-        <ReportChapterTableResult {standard} {chapterId} {criteria} {download} />
+        <ReportChapterTableResult {catalogName} {standard} {chapterId} {criteria} {download} />
       {/each}
     </tbody>
   </table>

--- a/src/components/report/ReportChapterTableResult.svelte
+++ b/src/components/report/ReportChapterTableResult.svelte
@@ -2,12 +2,13 @@
   import { catalogChapterCriteria, catalogComponentLabel, levelLabel } from "../../utils/getCatalogItems.js";
   import { sanitizeMarkdown } from "../../utils/sanitizeMarkdown.js";
 
+  export let catalogName;
   export let standard;
   export let chapterId;
   export let criteria;
   export let download = false;
 
-  $: catalogCriteria = catalogChapterCriteria(chapterId, criteria.num);
+  $: catalogCriteria = catalogChapterCriteria(catalogName, chapterId, criteria.num);
   const extraId = download ? "-download" : "-editor";
 </script>
 
@@ -46,7 +47,7 @@
       <ul>
         {#each criteria.components as component}
           {#if component.adherence.level}
-            <li>{@html catalogComponentLabel(component.name, "html")}<p>{levelLabel(component.adherence.level)}</p></li>
+            <li>{@html catalogComponentLabel(catalogName, component.name, "html")}<p>{levelLabel(catalogName, component.adherence.level)}</p></li>
           {/if}
         {/each}
       </ul>
@@ -57,7 +58,7 @@
       <ul>
         {#each criteria.components as component}
         {#if component.adherence.notes}
-          <li>{@html catalogComponentLabel(component.name, "html")}{@html sanitizeMarkdown(component.adherence.notes)}</li>
+          <li>{@html catalogComponentLabel(catalogName, component.name, "html")}{@html sanitizeMarkdown(component.adherence.notes)}</li>
           {/if}
         {/each}
       </ul>

--- a/src/components/report/ReportChapterTableResult.svelte
+++ b/src/components/report/ReportChapterTableResult.svelte
@@ -36,6 +36,7 @@
   }
 </style>
 
+{#if catalogCriteria }
 <tr class="result-row" id="{catalogCriteria.alt_id}{extraId}">
   <td>
     <a href="{standard.url}#{catalogCriteria.alt_id}" target="_blank">
@@ -65,3 +66,4 @@
     {/if}
   </td>
 </tr>
+{/if}

--- a/src/components/report/ReportHTMLDownload.svelte
+++ b/src/components/report/ReportHTMLDownload.svelte
@@ -10,11 +10,12 @@
   import { createHTMLDownload } from "../../utils/createHTMLDownload.js";
   import { validate } from "../../utils/validate.js";
   import { reportFilename } from "../../utils/reportFilename.js";
-  import { standards } from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
+  import { getCatalog } from "../../utils/getCatalogs.js";
 
   var title = $evaluation.title;
   const filename = reportFilename($evaluation);
   const valid = validate($evaluation);
+  let catalog = getCatalog($evaluation.catalog);
   let htmlDownload, htmlDownloadTemplate;
 
   let download = true;
@@ -114,7 +115,7 @@
   <main>
     <div class="grid-container">
       <ReportHeader {download} />
-      {#each standards as standard}
+      {#each catalog.standards as standard}
         <ReportChapters {standard} {download} />
       {/each}
       <ReportSummary {download} />

--- a/src/components/report/ReportHeader.svelte
+++ b/src/components/report/ReportHeader.svelte
@@ -2,14 +2,15 @@
   import Header from "../Header.svelte";
   import HeaderWithAnchor from "../HeaderWithAnchor.svelte";
   import { evaluation } from "../../stores/evaluation.js";
-  import catalog from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
   import { standardsIncluded } from "../../utils/getCatalogItems.js";
   import { sanitizeMarkdown } from "../../utils/sanitizeMarkdown.js";
   import { reportFilename } from "../../utils/reportFilename.js";
+  import { getCatalog } from "../../utils/getCatalogs.js";
 
   $evaluation.title = $evaluation["product"]["name"] + " Accessibility Conformance Report";
 
   export let download = false;
+  let catalog = getCatalog($evaluation.catalog);
 </script>
 
 <Header>{$evaluation.title}</Header>
@@ -78,7 +79,7 @@ This report covers the degree of conformance for the following accessibility sta
     {#each catalog.standards as standard }
       <tr>
         <td><a href="{standard.url}" target="_blank">{standard.label} <span class="visuallyhidden">(opens in a new window or tab)</span></a></td>
-        <td>{@html standardsIncluded(standard.chapters)}</td>
+        <td>{@html standardsIncluded($evaluation.catalog, standard.chapters)}</td>
       </tr>
     {/each}
   </tbody>

--- a/src/components/report/ReportMarkdownDownload.svelte
+++ b/src/components/report/ReportMarkdownDownload.svelte
@@ -1,14 +1,15 @@
 <script>
   import { onMount } from "svelte";
   import { evaluation } from "../../stores/evaluation.js";
-  import catalog from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
   import { validate } from "../../utils/validate.js";
   import { reportFilename } from "../../utils/reportFilename.js";
   import { license } from "../../utils/license.js";
   import { standardsIncluded } from "../../utils/getCatalogItems.js";
+  import { getCatalog } from "../../utils/getCatalogs.js";
 
   const filename = reportFilename($evaluation);
   const valid = validate($evaluation);
+  let catalog = getCatalog($evaluation.catalog);
   let mdDownload, mdTemplate, licenseOutput;
 
   if (valid.result) {
@@ -70,7 +71,7 @@ This report covers the degree of conformance for the following accessibility sta
 
   catalog.standards.forEach(standard => {
     mdTemplate += `
-| [${standard.label}](${standard.url}) | ${standardsIncluded(standard.chapters)} |`;
+| [${standard.label}](${standard.url}) | ${standardsIncluded($evaluation.catalog, standard.chapters)} |`;
   });
 
   mdTemplate += `

--- a/src/components/report/ReportZipDownload.svelte
+++ b/src/components/report/ReportZipDownload.svelte
@@ -1,7 +1,6 @@
 <script>
   import { onMount } from "svelte";
   import { evaluation } from "../../stores/evaluation.js";
-
   import ReportHeader from "./ReportHeader.svelte";
   import ReportSummary from "./ReportSummary.svelte";
   import ReportChapters from "./ReportChapters.svelte";
@@ -10,15 +9,16 @@
   import { createHTMLDownload } from "../../utils/createHTMLDownload.js";
   import { validate } from "../../utils/validate.js";
   import { reportFilename } from "../../utils/reportFilename.js";
-  import { standards } from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
   import yaml from "js-yaml";
   import JSZip from "jszip";
   import { sanitizeEvaluation } from "../../utils/sanitizeEvaluation.js";
+  import { getCatalog } from "../../utils/getCatalogs.js";
 
   var title = $evaluation.title;
   const filename = reportFilename($evaluation);
   const sanitizedEvaluation = sanitizeEvaluation($evaluation);
   const valid = validate($evaluation);
+  let catalog = getCatalog($evaluation.catalog);
   let zipDownload, htmlDownload, htmlDownloadTemplate;
 
   let download = true;
@@ -124,7 +124,7 @@
   <main>
     <div class="grid-container">
       <ReportHeader {download} />
-      {#each standards as standard}
+      {#each catalog.standards as standard}
         <ReportChapters {standard} {download} />
       {/each}
       <ReportSummary {download} />

--- a/src/data/helpText.yaml
+++ b/src/data/helpText.yaml
@@ -43,3 +43,5 @@ disabled_chapters:
   hardware: ""
   software: ""
   support_documentation_and_services: ""
+catalog:
+  intro: "Select which catalog you will be using for the OpenACR."

--- a/src/routes/About.svelte
+++ b/src/routes/About.svelte
@@ -16,10 +16,11 @@
   import HeaderWithAnchor from "../components/HeaderWithAnchor.svelte";
   import ExpandCollapseAll from "../components/ExpandCollapseAll.svelte";
   import { honourFragmentIdLinks } from "../utils/honourFragmentIdLinks.js";
-  import { chapters } from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
   import { reportFilename } from "../utils/reportFilename.js";
+  import { getCatalog } from "../utils/getCatalogs.js";
 
   const location = useLocation();
+  let catalog = getCatalog($evaluation.catalog);
 
   onMount(() => {
     currentPage.update(currentPage => "About");
@@ -390,7 +391,7 @@
 
   <p>{helpText["disabled_chapters"]["intro"]}</p>
 
-  {#each chapters as chapter}
+  {#each catalog.chapters as chapter}
     <div class="field">
       <label>
         <input

--- a/src/routes/About.svelte
+++ b/src/routes/About.svelte
@@ -17,10 +17,12 @@
   import ExpandCollapseAll from "../components/ExpandCollapseAll.svelte";
   import { honourFragmentIdLinks } from "../utils/honourFragmentIdLinks.js";
   import { reportFilename } from "../utils/reportFilename.js";
-  import { getCatalog } from "../utils/getCatalogs.js";
+  import { getCatalog, getListOfCatalogs } from "../utils/getCatalogs.js";
+  import { updateEvaluation } from "../utils/updateEvaluation.js";
 
   const location = useLocation();
   let catalog = getCatalog($evaluation.catalog);
+  let catalogChoices = getListOfCatalogs();
 
   onMount(() => {
     currentPage.update(currentPage => "About");
@@ -81,6 +83,16 @@
     }
   }
 
+  function updateCatalog(e) {
+    if (
+      window.confirm(
+        "This may remove criteria that are not in the selected catalog. Are you sure that's what you'd like to do?"
+      )
+    ) {
+      updateEvaluation(e.target.value, $evaluation);
+    }
+  }
+
   $: versionPrefix = reportFilename($evaluation, false);
 </script>
 
@@ -106,6 +118,27 @@
   />
 
 <ExpandCollapseAll />
+
+<details open>
+  <summary>
+    <HeaderWithAnchor id="select-catalog" level=2>Select catalog</HeaderWithAnchor>
+  </summary>
+  <p>{helpText["catalog"]["intro"]}</p>
+  {#each catalogChoices as catalogChoice}
+    <div class="field">
+      <label>
+        <input
+          type="radio"
+          value={catalogChoice.catalog}
+          bind:group="{$evaluation['catalog']}"
+          id="evaluation-catalog-{catalogChoice.catalog}"
+          on:change={updateCatalog} />
+
+        {catalogChoice.title}
+      </label>
+    </div>
+  {/each}
+</details>
 
 <details open>
   <summary>

--- a/src/routes/Overview.svelte
+++ b/src/routes/Overview.svelte
@@ -10,6 +10,7 @@
   import { honourFragmentIdLinks } from "../utils/honourFragmentIdLinks.js";
   import { evaluation } from "../stores/evaluation.js";
   import { getCatalog, getListOfCatalogs } from "../utils/getCatalogs.js";
+  import { updateEvaluation } from "../utils/updateEvaluation.js";
 
   const location = useLocation();
   let catalog = getCatalog($evaluation.catalog);
@@ -20,6 +21,16 @@
 
     honourFragmentIdLinks($location);
   });
+
+  function updateCatalog(e) {
+    if (
+      window.confirm(
+        "This may removed fields that are not in the selected catalog. Are you sure that's what you'd like to do?"
+      )
+    ) {
+      updateEvaluation(e.target.value, $evaluation);
+    }
+  }
 </script>
 
 <svelte:head>
@@ -74,7 +85,7 @@
           value={catalogChoice.catalog}
           bind:group="{$evaluation['catalog']}"
           id="evaluation-catalog-{catalogChoice.catalog}"
-          on:change={() => evaluation.updateCache($evaluation)} />
+          on:change={updateCatalog} />
 
         {catalogChoice.title}
       </label>

--- a/src/routes/Overview.svelte
+++ b/src/routes/Overview.svelte
@@ -9,28 +9,16 @@
   import HeaderWithAnchor from "../components/HeaderWithAnchor.svelte";
   import { honourFragmentIdLinks } from "../utils/honourFragmentIdLinks.js";
   import { evaluation } from "../stores/evaluation.js";
-  import { getCatalog, getListOfCatalogs } from "../utils/getCatalogs.js";
-  import { updateEvaluation } from "../utils/updateEvaluation.js";
+  import { getCatalog } from "../utils/getCatalogs.js";
 
   const location = useLocation();
   let catalog = getCatalog($evaluation.catalog);
-  let catalogChoices = getListOfCatalogs();
 
   onMount(() => {
     currentPage.update((currentPage) => "Overview");
 
     honourFragmentIdLinks($location);
   });
-
-  function updateCatalog(e) {
-    if (
-      window.confirm(
-        "This may remove criteria that are not in the selected catalog. Are you sure that's what you'd like to do?"
-      )
-    ) {
-      updateEvaluation(e.target.value, $evaluation);
-    }
-  }
 </script>
 
 <svelte:head>
@@ -69,29 +57,6 @@
 </ul>
 
 <ExpandCollapseAll />
-
-<details open>
-  <summary>
-    <HeaderWithAnchor id="select-catalog" level=2>Select catalog</HeaderWithAnchor>
-  </summary>
-  <p>
-    Select which catalog you will be using for the OpenACR.
-  </p>
-  {#each catalogChoices as catalogChoice}
-    <div class="field">
-      <label>
-        <input
-          type="radio"
-          value={catalogChoice.catalog}
-          bind:group="{$evaluation['catalog']}"
-          id="evaluation-catalog-{catalogChoice.catalog}"
-          on:change={updateCatalog} />
-
-        {catalogChoice.title}
-      </label>
-    </div>
-  {/each}
-</details>
 
 <details>
   <summary>

--- a/src/routes/Overview.svelte
+++ b/src/routes/Overview.svelte
@@ -6,11 +6,13 @@
   import Pager from "../components/Pager.svelte";
   import PagerLink from "../components/PagerLink.svelte";
   import { currentPage } from "../stores/currentPage.js";
-  import { terms } from '@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml';
   import HeaderWithAnchor from "../components/HeaderWithAnchor.svelte";
   import { honourFragmentIdLinks } from "../utils/honourFragmentIdLinks.js";
+  import { evaluation } from "../stores/evaluation.js";
+  import { getCatalog } from "../utils/getCatalogs.js";
 
   const location = useLocation();
+  let catalog = getCatalog($evaluation.catalog);
 
   onMount(() => {
     currentPage.update((currentPage) => "Overview");
@@ -111,7 +113,7 @@
     each component. Here is the legend of what those selections mean:
   </p>
   <dl>
-    {#each terms as term}
+    {#each catalog.terms as term}
       <dt>{term.label}</dt>
       <dd>{term.description}</dd>
     {/each}

--- a/src/routes/Overview.svelte
+++ b/src/routes/Overview.svelte
@@ -25,7 +25,7 @@
   function updateCatalog(e) {
     if (
       window.confirm(
-        "This may removed fields that are not in the selected catalog. Are you sure that's what you'd like to do?"
+        "This may remove criteria that are not in the selected catalog. Are you sure that's what you'd like to do?"
       )
     ) {
       updateEvaluation(e.target.value, $evaluation);
@@ -75,7 +75,7 @@
     <HeaderWithAnchor id="select-catalog" level=2>Select catalog</HeaderWithAnchor>
   </summary>
   <p>
-    Select which catalog will you be using for this OpenACR.
+    Select which catalog you will be using for the OpenACR.
   </p>
   {#each catalogChoices as catalogChoice}
     <div class="field">

--- a/src/routes/Overview.svelte
+++ b/src/routes/Overview.svelte
@@ -9,10 +9,11 @@
   import HeaderWithAnchor from "../components/HeaderWithAnchor.svelte";
   import { honourFragmentIdLinks } from "../utils/honourFragmentIdLinks.js";
   import { evaluation } from "../stores/evaluation.js";
-  import { getCatalog } from "../utils/getCatalogs.js";
+  import { getCatalog, getListOfCatalogs } from "../utils/getCatalogs.js";
 
   const location = useLocation();
   let catalog = getCatalog($evaluation.catalog);
+  let catalogChoices = getListOfCatalogs();
 
   onMount(() => {
     currentPage.update((currentPage) => "Overview");
@@ -57,6 +58,29 @@
 </ul>
 
 <ExpandCollapseAll />
+
+<details open>
+  <summary>
+    <HeaderWithAnchor id="select-catalog" level=2>Select catalog</HeaderWithAnchor>
+  </summary>
+  <p>
+    Select which catalog will you be using for this OpenACR.
+  </p>
+  {#each catalogChoices as catalogChoice}
+    <div class="field">
+      <label>
+        <input
+          type="radio"
+          value={catalogChoice.catalog}
+          bind:group="{$evaluation['catalog']}"
+          id="evaluation-catalog-{catalogChoice.catalog}"
+          on:change={() => evaluation.updateCache($evaluation)} />
+
+        {catalogChoice.title}
+      </label>
+    </div>
+  {/each}
+</details>
 
 <details>
   <summary>

--- a/src/routes/Report.svelte
+++ b/src/routes/Report.svelte
@@ -1,7 +1,6 @@
 <script>
   import { onMount } from "svelte";
   import { useLocation } from "svelte-navigator";
-  import Header from "../components/Header.svelte";
   import HeaderWithAnchor from "../components/HeaderWithAnchor.svelte";
   import ReportHeader from "../components/report/ReportHeader.svelte";
   import ReportSummary from "../components/report/ReportSummary.svelte";
@@ -10,12 +9,13 @@
   import ReportChapters from "../components/report/ReportChapters.svelte";
   import ReportZipDownload from "../components/report/ReportZipDownload.svelte";
   import ReportYAMLDownload from "../components/report/ReportYAMLDownload.svelte";
-  import { standards } from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
   import { evaluation } from "../stores/evaluation.js";
   import { currentPage } from "../stores/currentPage.js";
   import { honourFragmentIdLinks } from "../utils/honourFragmentIdLinks.js";
+  import { getCatalog } from "../utils/getCatalogs.js";
 
   const location = useLocation();
+  let catalog = getCatalog($evaluation.catalog);
 
   onMount(() => {
     currentPage.update(currentPage => "Report");
@@ -53,7 +53,7 @@
 </details>
 
 <ReportHeader />
-{#each standards as standard}
+{#each catalog.standards as standard}
   <ReportChapters {standard} />
 {/each}
 <ReportSummary />

--- a/src/stores/evaluation.js
+++ b/src/stores/evaluation.js
@@ -4,7 +4,7 @@ import { createCleanEvaluation } from "../utils/createCleanEvaluation.js";
 const storageName = "openacr_editor_store";
 
 // update this number whenever new things added to the data model to cachebust [remove this when stable]
-const DATA_MODEL = "23";
+const DATA_MODEL = "24";
 
 let fresh = true;
 

--- a/src/utils/createCleanEvaluation.js
+++ b/src/utils/createCleanEvaluation.js
@@ -1,7 +1,8 @@
 import { validate } from "../utils/validate.js";
-import { chapters } from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
+import { getDefaultCatalogName, getCatalog } from "../utils/getCatalogs.js";
 
 const datestamp = new Date().toLocaleDateString();
+const defaultCatalogName = getDefaultCatalogName();
 
 export function createCleanEvaluation() {
   const cleanEvaluation = {
@@ -37,10 +38,12 @@ export function createCleanEvaluation() {
     feedback: "",
     license: "CC-BY-4.0",
     related_openacrs: [],
+    catalog: defaultCatalogName,
     chapters: {},
   };
 
-  for (const chapter of chapters) {
+  let catalog = getCatalog(defaultCatalogName);
+  for (const chapter of catalog.chapters) {
     const criteria = [];
     for (const chapterCriteria of chapter.criteria) {
       const components = [];

--- a/src/utils/getCatalogItems.js
+++ b/src/utils/getCatalogItems.js
@@ -1,7 +1,8 @@
-import catalog from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
 import sanitizeHtml from "sanitize-html";
+import { getCatalog } from "../utils/getCatalogs.js";
 
-export function getCatalogChapter(chapterId) {
+export function getCatalogChapter(catalogName, chapterId) {
+  let catalog = getCatalog(catalogName);
   for (const chapter of catalog.chapters) {
     if (chapter.id === chapterId) {
       return chapter;
@@ -9,17 +10,17 @@ export function getCatalogChapter(chapterId) {
   }
 }
 
-export function standardsIncluded(standardChapters) {
+export function standardsIncluded(catalogName, standardChapters) {
   const result = [];
   for (const standardChapter of standardChapters) {
-    const catalogChapter = getCatalogChapter(standardChapter);
+    const catalogChapter = getCatalogChapter(catalogName, standardChapter);
     result.push(`<li>${catalogChapter.label}</li>`);
   }
   return sanitizeHtml(`<ul>${result.join("")}</ul>`);
 }
 
-export function catalogChapterCriteria(chapterId, criteriaNum) {
-  const catalogChapter = getCatalogChapter(chapterId);
+export function catalogChapterCriteria(catalogName, chapterId, criteriaNum) {
+  const catalogChapter = getCatalogChapter(catalogName, chapterId);
   for (const catalogChapterCriteria of catalogChapter.criteria) {
     if (catalogChapterCriteria.id === criteriaNum) {
       return catalogChapterCriteria;
@@ -27,7 +28,8 @@ export function catalogChapterCriteria(chapterId, criteriaNum) {
   }
 }
 
-export function catalogComponentLabel(componentId, templateType) {
+export function catalogComponentLabel(catalogName, componentId, templateType) {
+  let catalog = getCatalog(catalogName);
   if (catalog.components) {
     for (const component of catalog.components) {
       if (component.id === componentId) {
@@ -44,7 +46,8 @@ export function catalogComponentLabel(componentId, templateType) {
   return "";
 }
 
-export function levelLabel(level) {
+export function levelLabel(catalogName, level) {
+  let catalog = getCatalog(catalogName);
   if (catalog.terms) {
     for (const terms of catalog.terms) {
       if (terms.id === level) {

--- a/src/utils/getCatalogs.js
+++ b/src/utils/getCatalogs.js
@@ -1,11 +1,17 @@
 import wcag20508catalog from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
+import wcag21catalog from "@openacr/openacr/catalog/2.4-edition-wcag-2.1-en.yaml";
+import wcag21508catalog from "@openacr/openacr/catalog/2.4-edition-wcag-2.1-508-en.yaml";
 const wcag20508catalogName = "2.4-edition-wcag-2.0-508-en";
 const wcag21catalogName = "2.4-edition-wcag-2.1-en";
 const wcag21508catalogName = "2.4-edition-wcag-2.1-508-en";
 
 export function getCatalog(catalogName) {
-  if (catalogName === wcag20508catalogName) {
+  if (catalogName == wcag20508catalogName) {
     return wcag20508catalog;
+  } else if (catalogName == wcag21catalogName) {
+    return wcag21catalog;
+  } else if (catalogName == wcag21508catalogName) {
+    return wcag21508catalog;
   }
   return null;
 }
@@ -14,7 +20,15 @@ export function getListOfCatalogs() {
   return [
     {
       catalog: wcag20508catalogName,
-      title: wcag20508catalog.title,
+      title: `${wcag20508catalog.title} (WCAG 2.0)`,
+    },
+    {
+      catalog: wcag21508catalogName,
+      title: `${wcag21508catalog.title}`,
+    },
+    {
+      catalog: wcag21catalogName,
+      title: `${wcag21catalog.title} (WCAG 2.1)`,
     },
   ];
 }

--- a/src/utils/getCatalogs.js
+++ b/src/utils/getCatalogs.js
@@ -1,7 +1,7 @@
 import wcag20508catalog from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
 import wcag21catalog from "@openacr/openacr/catalog/2.4-edition-wcag-2.1-en.yaml";
 import wcag21508catalog from "@openacr/openacr/catalog/2.4-edition-wcag-2.1-508-en.yaml";
-const wcag20508catalogName = "2.4-edition-wcag-2.0-508-en";
+export const wcag20508catalogName = "2.4-edition-wcag-2.0-508-en";
 const wcag21catalogName = "2.4-edition-wcag-2.1-en";
 const wcag21508catalogName = "2.4-edition-wcag-2.1-508-en";
 

--- a/src/utils/getCatalogs.js
+++ b/src/utils/getCatalogs.js
@@ -1,0 +1,24 @@
+import wcag20508catalog from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
+const wcag20508catalogName = "2.4-edition-wcag-2.0-508-en";
+const wcag21catalogName = "2.4-edition-wcag-2.1-en";
+const wcag21508catalogName = "2.4-edition-wcag-2.1-508-en";
+
+export function getCatalog(catalogName) {
+  if (catalogName === wcag20508catalogName) {
+    return wcag20508catalog;
+  }
+  return null;
+}
+
+export function getListOfCatalogs() {
+  return [
+    {
+      catalog: wcag20508catalogName,
+      title: wcag20508catalog.title,
+    },
+  ];
+}
+
+export function getDefaultCatalogName() {
+  return wcag20508catalogName;
+}

--- a/src/utils/getEvaluatedItems.js
+++ b/src/utils/getEvaluatedItems.js
@@ -1,4 +1,4 @@
-import { chapters } from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
+import { getCatalog } from "../utils/getCatalogs.js";
 
 export function getProgressPerChapter(evaluation) {
   let progressPerChapter = {};
@@ -31,7 +31,8 @@ export function getProgressPerChapter(evaluation) {
     return components.length;
   }
 
-  chapters.forEach((chapter) => {
+  let catalog = getCatalog(evaluation.catalog);
+  catalog.chapters.forEach((chapter) => {
     const total = getTotalForChapter(chapter);
     const evaluated = getEvaluatedForChapter(chapter);
 
@@ -50,8 +51,9 @@ export function getEvaluatedChapterCriteriaComponents(evaluation) {
     evaluation.chapters &&
     Object.keys(evaluation.chapters).length > 0
   ) {
+    let catalog = getCatalog(evaluation.catalog);
     const components = [];
-    chapters.forEach((chapter) => {
+    catalog.chapters.forEach((chapter) => {
       if (
         evaluation.chapters[chapter.id].criteria &&
         !evaluation.chapters[chapter.id].disabled
@@ -76,8 +78,9 @@ export function getEvaluatedChapterCriteriaComponents(evaluation) {
 }
 
 export function getChapterCriteriaComponents(evaluation) {
+  let catalog = getCatalog(evaluation.catalog);
   const components = [];
-  chapters.forEach((chapter) => {
+  catalog.chapters.forEach((chapter) => {
     if (!evaluation.chapters[chapter.id].disabled) {
       chapter.criteria.forEach((item) => {
         item.components.forEach((component) => {

--- a/src/utils/importEvaluation.js
+++ b/src/utils/importEvaluation.js
@@ -1,11 +1,12 @@
 import { evaluation } from "../stores/evaluation.js";
 import { validate } from "../utils/validate.js";
-import { chapters } from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
 import yaml from "js-yaml";
+import { getDefaultCatalogName, getCatalog } from "../utils/getCatalogs.js";
 
 export function importEvaluation(event) {
   var files = event.target.files;
   const datestamp = new Date().toLocaleDateString();
+  const defaultCatalogName = getDefaultCatalogName();
 
   for (var i = 0, file; (file = files[i]); i++) {
     if (!file.type.match("application/x-yaml")) {
@@ -44,9 +45,13 @@ export function importEvaluation(event) {
         if (!converted.related_openacrs) {
           converted["related_openacrs"] = [];
         }
+        if (!converted.catalog) {
+          converted["catalog"] = defaultCatalogName;
+        }
 
         // Initialize any missing chapters, components, and criteria.
-        for (const chapter of chapters) {
+        let catalog = getCatalog(converted.catalog);
+        for (const chapter of catalog.chapters) {
           if (!converted["chapters"][chapter.id]) {
             converted["chapters"][chapter.id] = {
               notes: "",

--- a/src/utils/sanitizeEvaluation.js
+++ b/src/utils/sanitizeEvaluation.js
@@ -1,8 +1,9 @@
 import sanitizeHtml from "sanitize-html";
-import { chapters } from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
+import { getCatalog } from "../utils/getCatalogs.js";
 
 export function sanitizeEvaluation(evaluation) {
-  for (const chapter of chapters) {
+  let catalog = getCatalog(evaluation.catalog);
+  for (const chapter of catalog.chapters) {
     for (
       let chapterCriteriaIndex = 0;
       chapterCriteriaIndex <

--- a/src/utils/updateEvaluation.js
+++ b/src/utils/updateEvaluation.js
@@ -96,8 +96,19 @@ export function initializeMissingChapters(catalogName, converted) {
         });
       }
     }
+    converted["chapters"][chapter.id].criteria.sort(sortCriteria);
   }
   return converted;
+}
+
+function sortCriteria(firstCriteria, secondCriteria) {
+  if (firstCriteria.num < secondCriteria.num) {
+    return -1;
+  }
+  if (firstCriteria.num > secondCriteria.num) {
+    return 1;
+  }
+  return 0;
 }
 
 function removeCriteria(chapterId, criteria, converted) {

--- a/src/utils/updateEvaluation.js
+++ b/src/utils/updateEvaluation.js
@@ -1,6 +1,7 @@
 import { evaluation } from "../stores/evaluation.js";
 import { validate } from "../utils/validate.js";
 import { getCatalog, wcag20508catalogName } from "./getCatalogs.js";
+import compareVersions from "compare-versions";
 
 export function updateEvaluation(catalogName, converted) {
   converted = initializeMissingChapters(catalogName, converted);
@@ -96,19 +97,19 @@ export function initializeMissingChapters(catalogName, converted) {
         });
       }
     }
-    converted["chapters"][chapter.id].criteria.sort(sortCriteria);
+    if (
+      chapter.id === "success_criteria_level_a" ||
+      chapter.id === "success_criteria_level_aa" ||
+      chapter.id === "success_criteria_level_aaa"
+    ) {
+      converted["chapters"][chapter.id].criteria.sort(sortCriteria);
+    }
   }
   return converted;
 }
 
 function sortCriteria(firstCriteria, secondCriteria) {
-  if (firstCriteria.num < secondCriteria.num) {
-    return -1;
-  }
-  if (firstCriteria.num > secondCriteria.num) {
-    return 1;
-  }
-  return 0;
+  return compareVersions(firstCriteria.num, secondCriteria.num);
 }
 
 function removeCriteria(chapterId, criteria, converted) {

--- a/src/utils/updateEvaluation.js
+++ b/src/utils/updateEvaluation.js
@@ -3,6 +3,46 @@ import { validate } from "../utils/validate.js";
 import { getCatalog, wcag20508catalogName } from "./getCatalogs.js";
 
 export function updateEvaluation(catalogName, converted) {
+  converted = initializeMissingChapters(catalogName, converted);
+
+  // Remove WCAG 2.1 items when switching to WCAG 2.0 catalog.
+  if (catalogName === wcag20508catalogName) {
+    // A
+    removeCriteria("success_criteria_level_a", "2.1.4", converted);
+    removeCriteria("success_criteria_level_a", "2.5.1", converted);
+    removeCriteria("success_criteria_level_a", "2.5.2", converted);
+    removeCriteria("success_criteria_level_a", "2.5.3", converted);
+    removeCriteria("success_criteria_level_a", "2.5.4", converted);
+    // AA
+    removeCriteria("success_criteria_level_aa", "1.3.4", converted);
+    removeCriteria("success_criteria_level_aa", "1.3.5", converted);
+    removeCriteria("success_criteria_level_aa", "1.4.10", converted);
+    removeCriteria("success_criteria_level_aa", "1.4.11", converted);
+    removeCriteria("success_criteria_level_aa", "1.4.12", converted);
+    removeCriteria("success_criteria_level_aa", "1.4.13", converted);
+    removeCriteria("success_criteria_level_aa", "4.1.3", converted);
+    // AAA
+    removeCriteria("success_criteria_level_aaa", "1.3.6", converted);
+    removeCriteria("success_criteria_level_aaa", "2.2.6", converted);
+    removeCriteria("success_criteria_level_aaa", "2.3.3", converted);
+    removeCriteria("success_criteria_level_aaa", "2.5.5", converted);
+    removeCriteria("success_criteria_level_aaa", "2.5.6", converted);
+  }
+
+  const valid = validate(converted);
+  if (valid.result) {
+    evaluation.update((evaluation) => converted);
+    evaluation.updateCache(converted, true);
+    alert("OpenACR passed validation when switching catalog.");
+  } else {
+    alert(
+      "OpenACR failed validation when trying to switch catalog. Message: " +
+        valid.message
+    );
+  }
+}
+
+export function initializeMissingChapters(catalogName, converted) {
   // Initialize any missing chapters, components, and criteria.
   let catalog = getCatalog(catalogName);
   for (const chapter of catalog.chapters) {
@@ -57,42 +97,7 @@ export function updateEvaluation(catalogName, converted) {
       }
     }
   }
-
-  // Remove WCAG 2.1 items when switching to WCAG 2.0 catalog.
-  if (catalogName === wcag20508catalogName) {
-    // A
-    removeCriteria("success_criteria_level_a", "2.1.4", converted);
-    removeCriteria("success_criteria_level_a", "2.5.1", converted);
-    removeCriteria("success_criteria_level_a", "2.5.2", converted);
-    removeCriteria("success_criteria_level_a", "2.5.3", converted);
-    removeCriteria("success_criteria_level_a", "2.5.4", converted);
-    // AA
-    removeCriteria("success_criteria_level_aa", "1.3.4", converted);
-    removeCriteria("success_criteria_level_aa", "1.3.5", converted);
-    removeCriteria("success_criteria_level_aa", "1.4.10", converted);
-    removeCriteria("success_criteria_level_aa", "1.4.11", converted);
-    removeCriteria("success_criteria_level_aa", "1.4.12", converted);
-    removeCriteria("success_criteria_level_aa", "1.4.13", converted);
-    removeCriteria("success_criteria_level_aa", "4.1.3", converted);
-    // AAA
-    removeCriteria("success_criteria_level_aaa", "1.3.6", converted);
-    removeCriteria("success_criteria_level_aaa", "2.2.6", converted);
-    removeCriteria("success_criteria_level_aaa", "2.3.3", converted);
-    removeCriteria("success_criteria_level_aaa", "2.5.5", converted);
-    removeCriteria("success_criteria_level_aaa", "2.5.6", converted);
-  }
-
-  const valid = validate(converted);
-  if (valid.result) {
-    evaluation.update((evaluation) => converted);
-    evaluation.updateCache(converted, true);
-    alert("OpenACR passed validation when switching catalog.");
-  } else {
-    alert(
-      "OpenACR failed validation when trying to switch catalog. Message: " +
-        valid.message
-    );
-  }
+  return converted;
 }
 
 function removeCriteria(chapterId, criteria, converted) {

--- a/src/utils/updateEvaluation.js
+++ b/src/utils/updateEvaluation.js
@@ -1,0 +1,108 @@
+import { evaluation } from "../stores/evaluation.js";
+import { validate } from "../utils/validate.js";
+import { getCatalog, wcag20508catalogName } from "./getCatalogs.js";
+
+export function updateEvaluation(catalogName, converted) {
+  // Initialize any missing chapters, components, and criteria.
+  let catalog = getCatalog(catalogName);
+  for (const chapter of catalog.chapters) {
+    if (!converted["chapters"][chapter.id]) {
+      converted["chapters"][chapter.id] = {
+        notes: "",
+        disabled: false,
+      };
+    }
+
+    if (!converted["chapters"][chapter.id]["criteria"]) {
+      converted["chapters"][chapter.id]["criteria"] = [];
+    }
+
+    for (const chapterCriteria of chapter.criteria) {
+      let currentEvaluationCriteria =
+        converted["chapters"] && converted["chapters"][chapter.id]["criteria"]
+          ? converted["chapters"][chapter.id]["criteria"].find(
+              ({ num }) => num === chapterCriteria.id
+            )
+          : null;
+      if (currentEvaluationCriteria) {
+        for (const component of chapterCriteria.components) {
+          let currentEvaluationComponent = currentEvaluationCriteria[
+            "components"
+          ].find(({ name }) => name === component);
+          if (!currentEvaluationComponent) {
+            currentEvaluationCriteria["components"].push({
+              name: component,
+              adherence: {
+                level: "",
+                notes: "",
+              },
+            });
+          }
+        }
+      } else {
+        const components = [];
+        for (const component of chapterCriteria.components) {
+          components.push({
+            name: component,
+            adherence: {
+              level: "",
+              notes: "",
+            },
+          });
+        }
+        converted["chapters"][chapter.id]["criteria"].push({
+          num: chapterCriteria.id,
+          components: components,
+        });
+      }
+    }
+  }
+
+  // Remove WCAG 2.1 items when switching to WCAG 2.0 catalog.
+  if (catalogName === wcag20508catalogName) {
+    // A
+    removeCriteria("success_criteria_level_a", "2.1.4", converted);
+    removeCriteria("success_criteria_level_a", "2.5.1", converted);
+    removeCriteria("success_criteria_level_a", "2.5.2", converted);
+    removeCriteria("success_criteria_level_a", "2.5.3", converted);
+    removeCriteria("success_criteria_level_a", "2.5.4", converted);
+    // AA
+    removeCriteria("success_criteria_level_aa", "1.3.4", converted);
+    removeCriteria("success_criteria_level_aa", "1.3.5", converted);
+    removeCriteria("success_criteria_level_aa", "1.4.10", converted);
+    removeCriteria("success_criteria_level_aa", "1.4.11", converted);
+    removeCriteria("success_criteria_level_aa", "1.4.12", converted);
+    removeCriteria("success_criteria_level_aa", "1.4.13", converted);
+    removeCriteria("success_criteria_level_aa", "4.1.3", converted);
+    // AAA
+    removeCriteria("success_criteria_level_aaa", "1.3.6", converted);
+    removeCriteria("success_criteria_level_aaa", "2.2.6", converted);
+    removeCriteria("success_criteria_level_aaa", "2.3.3", converted);
+    removeCriteria("success_criteria_level_aaa", "2.5.5", converted);
+    removeCriteria("success_criteria_level_aaa", "2.5.6", converted);
+  }
+
+  const valid = validate(converted);
+  if (valid.result) {
+    evaluation.update((evaluation) => converted);
+    evaluation.updateCache(converted, true);
+    alert("OpenACR passed validation when switching catalog.");
+  } else {
+    alert(
+      "OpenACR failed validation when trying to switch catalog. Message: " +
+        valid.message
+    );
+  }
+}
+
+function removeCriteria(chapterId, criteria, converted) {
+  let criteriaIndex =
+    converted["chapters"] && converted["chapters"][chapterId]["criteria"]
+      ? converted["chapters"][chapterId]["criteria"].findIndex(
+          ({ num }) => num === criteria
+        )
+      : null;
+  if (criteriaIndex) {
+    converted["chapters"][chapterId]["criteria"].splice(criteriaIndex, 1);
+  }
+}

--- a/src/utils/validate.js
+++ b/src/utils/validate.js
@@ -1,9 +1,10 @@
-import catalog from "@openacr/openacr/catalog/2.4-edition-wcag-2.0-508-en.yaml";
 import { validateOpenACR } from "@openacr/openacr/src/validateOpenACR.ts";
 import { validateOpenACRCatalogValues } from "@openacr/openacr/src/validateOpenACRCatalogValues.ts";
+import { getCatalog } from "./getCatalogs.js";
 
 export function validate(evaluation) {
   let valid = validateOpenACR(evaluation, "openacr-0.1.0.json");
+  let catalog = getCatalog(evaluation.catalog);
   if (valid.result) {
     valid = validateOpenACRCatalogValues(evaluation, catalog);
   }


### PR DESCRIPTION
Closes https://github.com/GSA/openacr/issues/270

Summary of changes:
* Moved catalog loading to a separate file+function. Added new catalogs from @openacr/openacr.
* Added a catalog radio field to the overview page to allow switching of catalogs.
* Added code to handle when switching catalogs to add missing fields and remove fields (e.g. remove WCAG 2.1 fields when switching to WCAG 2.0 to pass validation).
* Added tests.

**QA new report**

1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Click 'Start new report' or 'New report'.
3. On the overview page confirm you see 'Select catalog' accordion.
4. Confirm the accordion is expanded and has a radio choices below the text 'Select which catalog you will be using for the OpenACR.'
5. Confirm the choices are 'VPAT® 2.4 Revised Section 508 Edition (WCAG 2.0)', 'VPAT® 2.4 WCAG 2.1 and Revised Section 508 Edition', 'VPAT® 2.4 (WCAG 2.1)'.
6. Switch the choice from WCAG 2.0 to any of the other choices.
7. Confirm the chapters in the navigation changes and the sidebar changes when switching the choices.
8. Selecting WCAG 2.1 catalog.
9. Navigate to the chapter pages and confirm you see WCAG 2.1 criteria and links go to WCAG 2.1 pages.
10. Add some text, select some values.
11. Click the 'View report' or 'Report' tab.
12. Confirm you see a green 'Valid Report' box at the top of the report page with the message 'Your report has passed validation'.
13. Confirm the report has the WCAG 2.1 criteria and links go to WCAG 2.1 pages.
14. Download the YAML & HTML report.
15. Confirm the report has the WCAG 2.1 criteria and links go to WCAG 2.1 pages.
16. Go back to the 'Overview' page
17. Click 'Start new report' or 'New report'.
18. Click 'Open report'.
19. Upload the downloaded YAML file from step 14.
20. Confirm the catalog selection shows the WCAG 2.1 selection.

**QA existing report**

1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Click 'Start new report' or 'New report'.
3. Click 'Open report'.
4. Upload a yaml file from OpenACR that already has 'last modified date' and 'version' set to some values (if needed modify the YAML file to set those values before uploading). Try the 'drupal-9.yaml' or any of the yaml files from https://github.com/GSA/openacr/tree/main/openacr where last modified date is 11/16/2021 and version is 12.
5. Confirm the catalog selection shows the WCAG 2.0 selection.
6. Switch the choice from WCAG 2.0 to any of the other choices.
7. Navigate to the chapter pages and confirm you see WCAG 2.1 criteria and links go to WCAG 2.1 pages.
8. Add some text, select some values.
9. Click the 'View report' or 'Report' tab.
10. Confirm you see a green 'Valid Report' box at the top of the report page with the message 'Your report has passed validation'.
11. Confirm the report has the WCAG 2.1 criteria and links go to WCAG 2.1 pages.
12. Download the YAML & HTML report.
13. Confirm the report has the WCAG 2.1 criteria and links go to WCAG 2.1 pages.
14. Go back to the 'Overview' page
15. Click 'Start new report' or 'New report'.
16. Upload the downloaded YAML file from step 12.
17. Confirm the catalog selection shows the WCAG 2.1 selection.
18. Switch the choice **back to WCAG 2.0**.
19. Navigate to the chapter pages and confirm you **only** see WCAG 2.0 criteria and links go to WCAG 2.0 pages.
20. Click the 'View report' or 'Report' tab.
21. Confirm you see a green 'Valid Report' box at the top of the report page with the message 'Your report has passed validation'.
22. Confirm the report has the **only** see WCAG 2.0 criteria and links go to WCAG 2.0 pages.