### PR TITLE
Added an alert message when trying to upload a file that is not YAML

### DIFF
--- a/cypress/fixtures/invalid.txt
+++ b/cypress/fixtures/invalid.txt
@@ -1,0 +1,1 @@
+Not a YAML file.

--- a/cypress/integration/import.test.js
+++ b/cypress/integration/import.test.js
@@ -301,7 +301,7 @@ describe("Import", () => {
       .should("have.been.calledOnce")
       .and(
         "have.been.calledWith",
-        "The uploaded file has type plain/text which is invalid. Please use one of these types: 'application/x-yaml', 'application/yaml', 'text/yaml'."
+        `The uploaded file ${textExample.filename} has type ${fileType} which is invalid. Please use one of these types: 'application/x-yaml', 'application/yaml', 'text/yaml'.`
       );
   });
 });

--- a/cypress/integration/import.test.js
+++ b/cypress/integration/import.test.js
@@ -273,4 +273,35 @@ describe("Import", () => {
         "No data found or invalid import. Message: Cannot read properties of undefined (reading 'success_criteria_level_a')"
       );
   });
+
+  it(`should reject non YAML file upload`, () => {
+    const fileType = "plain/text";
+    const textExample = {
+      filename: "invalid.txt",
+    };
+    cy.fixture(textExample.filename).as("txtFixture");
+
+    cy.visit("/");
+
+    cy.on("window:alert", cy.stub().as("alerted"));
+
+    cy.get("input[type='file']").then(function ($input) {
+      const blob = Cypress.Blob.binaryStringToBlob(this.txtFixture, fileType);
+      const file = new File([blob], textExample.filename, { type: fileType });
+      const list = new DataTransfer();
+
+      list.items.add(file);
+      const myFileList = list.files;
+
+      $input[0].files = myFileList;
+      $input[0].dispatchEvent(new Event("change", { bubbles: true }));
+    });
+
+    cy.get("@alerted")
+      .should("have.been.calledOnce")
+      .and(
+        "have.been.calledWith",
+        "The uploaded file has type plain/text which is invalid. Please use one of these types: 'application/x-yaml', 'application/yaml', 'text/yaml'."
+      );
+  });
 });

--- a/src/routes/About.svelte
+++ b/src/routes/About.svelte
@@ -86,7 +86,7 @@
   function updateCatalog(e) {
     if (
       window.confirm(
-        "This may remove criteria that are not in the selected catalog. Are you sure that's what you'd like to do?"
+        "This may remove any entered criteria from your ACR that are not in the selected catalog. Download a copy of the report if you have not already. Are you sure that's what you'd like to do?"
       )
     ) {
       updateEvaluation(e.target.value, $evaluation);

--- a/src/utils/importEvaluation.js
+++ b/src/utils/importEvaluation.js
@@ -10,15 +10,20 @@ export function importEvaluation(event) {
   const defaultCatalogName = getDefaultCatalogName();
 
   for (var i = 0, file; (file = files[i]); i++) {
+    let fileType = file.type;
     if (
       !(
-        file.type.match("application/x-yaml") ||
-        file.type.match("application/yaml") ||
-        file.type.match("text/yaml")
+        fileType.match("application/x-yaml") ||
+        fileType.match("application/yaml") ||
+        fileType.match("text/yaml") ||
+        (fileType.match("") && file.name.split(".").pop() === "yaml")
       )
     ) {
+      if (fileType === "") {
+        fileType = "empty";
+      }
       alert(
-        `The uploaded file ${file.name} has type ${file.type} which is invalid. Please use one of these types: 'application/x-yaml', 'application/yaml', 'text/yaml'.`
+        `The uploaded file ${file.name} has type ${fileType} which is invalid. Please use one of these types: 'application/x-yaml', 'application/yaml', 'text/yaml'.`
       );
       return;
     }

--- a/src/utils/importEvaluation.js
+++ b/src/utils/importEvaluation.js
@@ -10,7 +10,16 @@ export function importEvaluation(event) {
   const defaultCatalogName = getDefaultCatalogName();
 
   for (var i = 0, file; (file = files[i]); i++) {
-    if (!file.type.match("application/x-yaml")) {
+    if (
+      !(
+        file.type.match("application/x-yaml") ||
+        file.type.match("application/yaml") ||
+        file.type.match("text/yaml")
+      )
+    ) {
+      alert(
+        `The uploaded file has type ${file.type} which is invalid. Please use one of these types: 'application/x-yaml', 'application/yaml', 'text/yaml'.`
+      );
       return;
     }
 

--- a/src/utils/importEvaluation.js
+++ b/src/utils/importEvaluation.js
@@ -18,7 +18,7 @@ export function importEvaluation(event) {
       )
     ) {
       alert(
-        `The uploaded file has type ${file.type} which is invalid. Please use one of these types: 'application/x-yaml', 'application/yaml', 'text/yaml'.`
+        `The uploaded file ${file.name} has type ${file.type} which is invalid. Please use one of these types: 'application/x-yaml', 'application/yaml', 'text/yaml'.`
       );
       return;
     }


### PR DESCRIPTION
Also added a test. Updated switching catalog alert https://github.com/GSA/openacr/issues/338.

Fixes https://github.com/GSA/openacr/issues/339 (maybe?)

**QA**

1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Click 'Start new report' or 'New report'.
3. Click 'Open report'.
4. Upload a yaml file from OpenACR that already has 'last modified date' and 'version' set to some values (if needed modify the YAML file to set those values before uploading). Try the 'drupal-9.yaml' or any of the yaml files from https://github.com/GSA/openacr/tree/main/openacr where last modified date is 11/16/2021 and version is 12.
5. Confirm the file uploads

**Bad file QA**

1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Click 'Start new report' or 'New report'.
3. Click 'Open report'.
4. Upload a file that is not YAML.
5. Confirm you get an alert stating that is does not match the required types.