### PR TITLE
Updated confirm text for switching catalog. Updated titles and help text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ public/build
 .vscode
 cypress/results
 .nova
+.DS_Store

--- a/cypress/fixtures/drupal-9.yaml
+++ b/cypress/fixtures/drupal-9.yaml
@@ -22,6 +22,7 @@ license: GPL-2.0-or-later
 related_openacrs:
   - url: https://ckeditor.com/docs/ckeditor4/latest/guide/dev_section508.html
     type: secondary
+catalog: "2.4-edition-wcag-2.0-508-en"
 chapters:
   success_criteria_level_a:
     notes: "Drupal doesn't make a strong distinction between the front-end & back-end accessibility. Many administration interfaces can be exposed to users in a more interactive site. Generally this report focuses the Conformance Level / Remarks and Explainations so that Web comments are about elements that are typically public, while Authoring Tool is typically for authors and administrators. The goal of the authoring interface is to support ATAG 2.0 AA (Part A and B). The Drupal community strives to beek up with the latest WCAG recommendation."

--- a/cypress/fixtures/govready-0.9.yaml
+++ b/cypress/fixtures/govready-0.9.yaml
@@ -25,6 +25,7 @@ evaluation_methods_used: >
   Testing was done through a combination of manual and automated testing. We leveraged automated tools WebAim's WAVE Toolbar and Microsoft's Accessibility Insights. Accessibility Insights leverages Deque's open source Axe accessibility engine. Manual testing was done using keyboard interactions and Apple's VoiceOver. Chrome v84 was used as the browser for all tests. Unique patterns were identified and tested to see where barriers might exist. Extensive testing of the site's functionality has been done based on this.
 legal_disclaimer: >
   The information herein is provided in good faith based on the analysis of the web application at the time of the review and does not represent a legally-binding claim. Please contact us to report any accessibility errors or conformance claim errors for re-evaluation and correction, if necessary.
+catalog: "2.4-edition-wcag-2.0-508-en"
 chapters:
   success_criteria_level_a:
     notes: "GovReady-Q is a web application and an authoring tool. As such the Software & Authoring Tool Notes are all included within the Web for the 'Conformance Level' and 'Remarks and Explanations'. There are some elements here that clearly fail WCAG 2.0 A."

--- a/cypress/integration/about.test.js
+++ b/cypress/integration/about.test.js
@@ -79,7 +79,7 @@ describe("About", () => {
 
     cy.get(".your-report__description").should(
       "contain",
-      `Reported on\n  0\n  of\n  258\n  Total Criteria.`
+      `Reported on\n  0\n  of\n  326\n  Total Criteria.`
     );
   });
 });

--- a/cypress/integration/catalog.test.js
+++ b/cypress/integration/catalog.test.js
@@ -1,6 +1,6 @@
 /// <reference types="Cypress" />
 
-const catalogs = ["2.4-edition-wcag-2.1-en", "2.4-edition-wcag-2.1-508-en"];
+const catalogs = ["2.4-edition-wcag-2.1-en", "2.4-edition-wcag-2.0-508-en"];
 const chapters = [
   "success_criteria_level_a",
   "success_criteria_level_aa",
@@ -94,7 +94,7 @@ describe("Catalogs", () => {
       .should("have.been.calledOnce")
       .and(
         "have.been.calledWith",
-        "Switching catalogs may remove entered data and notes from your ACR that are not part of the newly selected catalog. Please download your report before switching catalogs to avoid losing information. Select cancel to download your report from the Report page before proceeding. Are you sure that's what you'd like to do?"
+        "Switching catalogs may remove entered data and notes from your ACR that are not part of the newly selected catalog. Please download your report before switching catalogs to avoid losing information. Select cancel to download your report from the Report page before proceeding.\n\nAre you sure that's what you'd like to do?"
       );
   });
 
@@ -106,7 +106,7 @@ describe("Catalogs", () => {
 
     cy.get("button").contains("Reset").click();
 
-    cy.get(`input[value="2.4-edition-wcag-2.0-508-en"]`).should("be.checked");
+    cy.get(`input[value="2.4-edition-wcag-2.1-508-en"]`).should("be.checked");
   });
 
   it("toggle catalog and cancel confirmation", () => {
@@ -120,15 +120,11 @@ describe("Catalogs", () => {
 
     cy.get("button").contains("Confirm").click();
 
-    cy.visit("/chapter/success_criteria_level_a");
-
-    cy.get(`div[id="${wcag21Criteria}"]`).should("not.exist");
-
     cy.get("button").contains("View Report").click();
 
-    cy.get("#success_criteria_level_a-editor + table tbody tr").should(
-      "not.contain",
-      wcag21Criteria
+    cy.get("#content").should(
+      "contain",
+      "Based on VPAT® 2.4 WCAG 2.1 and Revised Section 508 Edition"
     );
   });
 });

--- a/cypress/integration/catalog.test.js
+++ b/cypress/integration/catalog.test.js
@@ -10,7 +10,7 @@ const wcag21Criteria = "2.1.4";
 
 describe("Catalogs", () => {
   catalogs.forEach((catalog) => {
-    it(`select catalog ${catalog} and load WCAG chapters and report without errors`, () => {
+    it(`select catalog ${catalog}, confirm and can load WCAG chapters and report without errors`, () => {
       cy.visit("/about");
 
       cy.get("button").contains("Confirm").should("be.disabled");
@@ -42,11 +42,11 @@ describe("Catalogs", () => {
     });
   });
 
-  it("toggle catalog and confirm a WCAG 2.1 criteria appears and disappears", () => {
+  it("toggle catalog, confirm and check for WCAG 2.1 criteria appearing and disappearing", () => {
     cy.visit("/about");
 
     // Switch to WCAG 2.1 catalog.
-    cy.get(`input[value="2.4-edition-wcag-2.1-en"]`).check();
+    cy.get("input[value='2.4-edition-wcag-2.1-en']").check();
 
     cy.get("button").contains("Confirm").click();
 
@@ -64,7 +64,7 @@ describe("Catalogs", () => {
     cy.visit("/about");
 
     // Switch back to WCAG 2.0 508 catalog.
-    cy.get(`input[value="2.4-edition-wcag-2.0-508-en"]`).check();
+    cy.get("input[value='2.4-edition-wcag-2.0-508-en']").check();
 
     cy.get("button").contains("Confirm").click();
 
@@ -80,13 +80,13 @@ describe("Catalogs", () => {
     );
   });
 
-  it("toggle catalog and confirm dialog message", () => {
+  it("toggle catalog, click confirm and see a confirmation dialog", () => {
     cy.visit("/about");
 
     cy.on("window:confirm", cy.stub().as("confirmation"));
 
     // Switch to WCAG 2.1 catalog.
-    cy.get(`input[value="2.4-edition-wcag-2.1-en"]`).check();
+    cy.get("input[value='2.4-edition-wcag-2.1-en']").check();
 
     cy.get("button").contains("Confirm").click();
 
@@ -98,6 +98,17 @@ describe("Catalogs", () => {
       );
   });
 
+  it("toggle catalog and reset it", () => {
+    cy.visit("/about");
+
+    // Switch to WCAG 2.1 catalog.
+    cy.get("input[value='2.4-edition-wcag-2.1-en']").check();
+
+    cy.get("button").contains("Reset").click();
+
+    cy.get(`input[value="2.4-edition-wcag-2.0-508-en"]`).should("be.checked");
+  });
+
   it("toggle catalog and cancel confirmation", () => {
     cy.visit("/about");
 
@@ -105,7 +116,7 @@ describe("Catalogs", () => {
     cy.on("window:confirm", () => false);
 
     // Switch to WCAG 2.1 catalog.
-    cy.get(`input[value="2.4-edition-wcag-2.1-en"]`).check();
+    cy.get("input[value='2.4-edition-wcag-2.1-en']").check();
 
     cy.get("button").contains("Confirm").click();
 

--- a/cypress/integration/catalog.test.js
+++ b/cypress/integration/catalog.test.js
@@ -13,16 +13,16 @@ describe("Catalogs", () => {
     it(`select catalog ${catalog}, confirm and can load WCAG chapters and report without errors`, () => {
       cy.visit("/about");
 
-      cy.get("button").contains("Confirm").should("be.disabled");
+      cy.get("button").contains("Switch Catalogs").should("be.disabled");
 
       cy.get(`input[value="${catalog}"]`).check();
 
       cy.get("p").should(
         "contain",
-        "Report type change is not saved till you confirm."
+        "Select Switch Catalogs to save your new selection."
       );
 
-      cy.get("button").contains("Confirm").click();
+      cy.get("button").contains("Switch Catalogs").click();
 
       chapters.forEach((chapter) => {
         cy.visit(`/chapter/${chapter}`, {
@@ -48,7 +48,7 @@ describe("Catalogs", () => {
     // Switch to WCAG 2.1 catalog.
     cy.get("input[value='2.4-edition-wcag-2.1-en']").check();
 
-    cy.get("button").contains("Confirm").click();
+    cy.get("button").contains("Switch Catalogs").click();
 
     cy.visit("/chapter/success_criteria_level_a");
 
@@ -66,7 +66,7 @@ describe("Catalogs", () => {
     // Switch back to WCAG 2.0 508 catalog.
     cy.get("input[value='2.4-edition-wcag-2.0-508-en']").check();
 
-    cy.get("button").contains("Confirm").click();
+    cy.get("button").contains("Switch Catalogs").click();
 
     cy.visit("/chapter/success_criteria_level_a");
 
@@ -88,13 +88,13 @@ describe("Catalogs", () => {
     // Switch to WCAG 2.1 catalog.
     cy.get("input[value='2.4-edition-wcag-2.1-en']").check();
 
-    cy.get("button").contains("Confirm").click();
+    cy.get("button").contains("Switch Catalogs").click();
 
     cy.get("@confirmation")
       .should("have.been.calledOnce")
       .and(
         "have.been.calledWith",
-        "Switching catalogs may remove entered data and notes from your ACR that are not part of the newly selected catalog. Please download your report before switching catalogs to avoid losing information. Select cancel to download your report from the Report page before proceeding.\n\nAre you sure that's what you'd like to do?"
+        "Switching catalogs may remove entered data and notes from your ACR that are not part of the newly selected catalog.\n\nPlease download your report before switching catalogs to avoid losing information. Select Cancel to save before switching."
       );
   });
 
@@ -118,7 +118,7 @@ describe("Catalogs", () => {
     // Switch to WCAG 2.1 catalog.
     cy.get("input[value='2.4-edition-wcag-2.1-en']").check();
 
-    cy.get("button").contains("Confirm").click();
+    cy.get("button").contains("Switch Catalogs").click();
 
     cy.get("button").contains("View Report").click();
 

--- a/cypress/integration/chapter.test.js
+++ b/cypress/integration/chapter.test.js
@@ -52,27 +52,27 @@ describe("Chapter", () => {
 
     cy.get(nonTextContentWebComponentLevelField).select("Supports");
 
-    cy.get(progressBarA).should("contain", "1 of 100");
+    cy.get(progressBarA).should("contain", "1 of 120");
 
     cy.get(nonTextContentWebComponentLevelField).select("Partially Supports");
 
-    cy.get(progressBarA).should("contain", "1 of 100");
+    cy.get(progressBarA).should("contain", "1 of 120");
 
     cy.get(nonTextContentWebComponentLevelField).select("Does Not Support");
 
-    cy.get(progressBarA).should("contain", "1 of 100");
+    cy.get(progressBarA).should("contain", "1 of 120");
 
     cy.get(nonTextContentWebComponentLevelField).select("Not Applicable");
 
-    cy.get(progressBarA).should("contain", "1 of 100");
+    cy.get(progressBarA).should("contain", "1 of 120");
 
     cy.get(nonTextContentWebComponentLevelField).select("Not Evaluated");
 
-    cy.get(progressBarA).should("contain", "1 of 100");
+    cy.get(progressBarA).should("contain", "1 of 120");
 
     cy.get(nonTextContentWebComponentLevelField).select("");
 
-    cy.get(progressBarA).should("contain", "0 of 100");
+    cy.get(progressBarA).should("contain", "0 of 120");
   });
 
   it("type notes and should see a message after adding 1 character, then a different message after more than 50 characters, and no message for 0 characters", () => {

--- a/cypress/integration/import.test.js
+++ b/cypress/integration/import.test.js
@@ -207,6 +207,8 @@ describe("Import", () => {
       .get(`input[value="2.4-edition-wcag-2.1-508-en"]`)
       .check();
 
+    cy.get("button").contains("Confirm").click();
+
     cy.get("@alerted")
       .should("have.been.calledTwice")
       .and(
@@ -226,6 +228,8 @@ describe("Import", () => {
     cy.visit("/about")
       .get(`input[value="2.4-edition-wcag-2.0-508-en"]`)
       .check();
+
+    cy.get("button").contains("Confirm").click();
 
     cy.get("@alerted")
       .should("have.been.calledThrice")

--- a/cypress/integration/import.test.js
+++ b/cypress/integration/import.test.js
@@ -207,7 +207,7 @@ describe("Import", () => {
       .get(`input[value="2.4-edition-wcag-2.1-508-en"]`)
       .check();
 
-    cy.get("button").contains("Confirm").click();
+    cy.get("button").contains("Switch Catalogs").click();
 
     cy.get("@alerted")
       .should("have.been.calledTwice")
@@ -229,7 +229,7 @@ describe("Import", () => {
       .get(`input[value="2.4-edition-wcag-2.0-508-en"]`)
       .check();
 
-    cy.get("button").contains("Confirm").click();
+    cy.get("button").contains("Switch Catalogs").click();
 
     cy.get("@alerted")
       .should("have.been.calledThrice")

--- a/cypress/integration/report.test.js
+++ b/cypress/integration/report.test.js
@@ -134,7 +134,7 @@ describe("Report", () => {
       "Does support non-text content."
     );
 
-    cy.get("a[href='/report#text-equiv-all-editor']").click();
+    cy.get("a[href='/report#non-text-content-editor']").click();
 
     cy.get("#success_criteria_level_a-editor + table tbody tr")
       .should("be.focused")
@@ -152,7 +152,7 @@ describe("Report", () => {
       "[Drupal 8](https://www.drupal.org/) requires alt text for images by default."
     );
 
-    cy.get("a[href='/report#text-equiv-all-editor']").click();
+    cy.get("a[href='/report#non-text-content-editor']").click();
 
     cy.get(
       "#success_criteria_level_a-editor + table tbody tr td:nth-child(3) a"

--- a/src/data/helpText.yaml
+++ b/src/data/helpText.yaml
@@ -45,6 +45,6 @@ disabled_chapters:
   support_documentation_and_services: ""
 catalog:
   intro: "Select which catalog you want to use for this OpenACR."
-  2.4-edition-wcag-2.0-508-en: "These are the minimum standards required for Section 508 conformance."
+  2.4-edition-wcag-2.0-508-en: "These are the minimum standards required for Section 508 conformance in the United States of America."
   2.4-edition-wcag-2.1-en: "This is a web-specific ACR that follows the global best practices for web accessibility."
   2.4-edition-wcag-2.1-508-en: "This is the current best practice standard in the United States of America."

--- a/src/data/helpText.yaml
+++ b/src/data/helpText.yaml
@@ -44,7 +44,7 @@ disabled_chapters:
   software: ""
   support_documentation_and_services: ""
 catalog:
-  intro: "Select which catalog you want to use for this OpenACR and confirm the change."
+  intro: "Select which catalog you want to use for this OpenACR."
   2.4-edition-wcag-2.0-508-en: "These are the minimum standards required for Section 508 conformance in the United States of America."
   2.4-edition-wcag-2.1-en: "This is a web-specific ACR that follows the global best practices for web accessibility."
   2.4-edition-wcag-2.1-508-en: "This is the current best practice standard in the United States of America."

--- a/src/data/helpText.yaml
+++ b/src/data/helpText.yaml
@@ -44,7 +44,7 @@ disabled_chapters:
   software: ""
   support_documentation_and_services: ""
 catalog:
-  intro: "Select which catalog you want to use for this OpenACR."
+  intro: "Select which catalog you want to use for this OpenACR and confirm the change."
   2.4-edition-wcag-2.0-508-en: "These are the minimum standards required for Section 508 conformance in the United States of America."
   2.4-edition-wcag-2.1-en: "This is a web-specific ACR that follows the global best practices for web accessibility."
   2.4-edition-wcag-2.1-508-en: "This is the current best practice standard in the United States of America."

--- a/src/data/helpText.yaml
+++ b/src/data/helpText.yaml
@@ -44,4 +44,7 @@ disabled_chapters:
   software: ""
   support_documentation_and_services: ""
 catalog:
-  intro: "Select which catalog you will be using for the OpenACR."
+  intro: "Select which catalog you want to use for this OpenACR."
+  2.4-edition-wcag-2.0-508-en: "These are the minimum standards required for Section 508 conformance."
+  2.4-edition-wcag-2.1-en: "This is a web-specific ACR that follows the global best practices for web accessibility."
+  2.4-edition-wcag-2.1-508-en: "This is the current best practice standard in the United States of America."

--- a/src/routes/About.svelte
+++ b/src/routes/About.svelte
@@ -86,7 +86,7 @@
   function updateCatalog(e) {
     if (
       window.confirm(
-        "Switching catalogs may remove entered data and notes from your ACR that are not part of the newly selected catalog. Please download your report before switching catalogs to avoid losing information. Are you sure that's what you'd like to do?"
+        "Switching catalogs may remove entered data and notes from your ACR that are not part of the newly selected catalog. Please download your report before switching catalogs to avoid losing information. Select cancel to download your report from the Report page before proceeding. Are you sure that's what you'd like to do?"
       )
     ) {
       updateEvaluation(e.target.value, $evaluation);

--- a/src/routes/About.svelte
+++ b/src/routes/About.svelte
@@ -99,6 +99,10 @@
     }
   }
 
+  function resetCatalogChange() {
+    selectedCatalog = $evaluation['catalog'];
+  }
+
   $: versionPrefix = reportFilename($evaluation, false);
 </script>
 
@@ -150,6 +154,7 @@
     <p><em>Report type change is not saved till you confirm.</em></p>
   {/if}
   <button class="button" on:click={confirmCatalogChange} disabled={$evaluation['catalog'] === selectedCatalog}>Confirm</button>
+  <button class="button" on:click={resetCatalogChange} disabled={$evaluation['catalog'] === selectedCatalog}>Reset</button>
 </details>
 
 <details open>

--- a/src/routes/About.svelte
+++ b/src/routes/About.svelte
@@ -91,7 +91,7 @@
   function confirmCatalogChange(e) {
     if (
       window.confirm(
-        "Switching catalogs may remove entered data and notes from your ACR that are not part of the newly selected catalog. Please download your report before switching catalogs to avoid losing information. Select cancel to download your report from the Report page before proceeding.\n\nAre you sure that's what you'd like to do?"
+        "Switching catalogs may remove entered data and notes from your ACR that are not part of the newly selected catalog.\n\nPlease download your report before switching catalogs to avoid losing information. Select Cancel to save before switching."
       )
     ) {
       $evaluation['catalog'] = selectedCatalog;
@@ -131,7 +131,7 @@
 
 <details open>
   <summary>
-    <HeaderWithAnchor id="select-catalog" level=2>Select report type (and catalog)</HeaderWithAnchor>
+    <HeaderWithAnchor id="select-catalog" level=2>Select report type and catalog</HeaderWithAnchor>
   </summary>
   <p>{helpText["catalog"]["intro"]}</p>
   {#each catalogChoices as catalogChoice}
@@ -151,9 +151,9 @@
   {/each}
 
   {#if $evaluation['catalog'] !== selectedCatalog }
-    <p><em>Report type change is not saved till you confirm.</em></p>
+    <p><em>Select Switch Catalogs to save your new selection.</em></p>
   {/if}
-  <button class="button" on:click={confirmCatalogChange} disabled={$evaluation['catalog'] === selectedCatalog}>Confirm</button>
+  <button class="button" on:click={confirmCatalogChange} disabled={$evaluation['catalog'] === selectedCatalog}>Switch Catalogs</button>
   <button class="button" on:click={resetCatalogChange} disabled={$evaluation['catalog'] === selectedCatalog}>Reset</button>
 </details>
 

--- a/src/routes/About.svelte
+++ b/src/routes/About.svelte
@@ -91,7 +91,7 @@
   function confirmCatalogChange(e) {
     if (
       window.confirm(
-        "Switching catalogs may remove entered data and notes from your ACR that are not part of the newly selected catalog. Please download your report before switching catalogs to avoid losing information. Select cancel to download your report from the Report page before proceeding. Are you sure that's what you'd like to do?"
+        "Switching catalogs may remove entered data and notes from your ACR that are not part of the newly selected catalog. Please download your report before switching catalogs to avoid losing information. Select cancel to download your report from the Report page before proceeding.\n\nAre you sure that's what you'd like to do?"
       )
     ) {
       $evaluation['catalog'] = selectedCatalog;

--- a/src/routes/About.svelte
+++ b/src/routes/About.svelte
@@ -86,7 +86,7 @@
   function updateCatalog(e) {
     if (
       window.confirm(
-        "This may remove any entered criteria from your ACR that are not in the selected catalog. Download a copy of the report if you have not already. Are you sure that's what you'd like to do?"
+        "Switching catalogs may remove entered data and notes from your ACR that are not part of the newly selected catalog. Please download your report before switching catalogs to avoid losing information. Are you sure that's what you'd like to do?"
       )
     ) {
       updateEvaluation(e.target.value, $evaluation);
@@ -121,7 +121,7 @@
 
 <details open>
   <summary>
-    <HeaderWithAnchor id="select-catalog" level=2>Select catalog</HeaderWithAnchor>
+    <HeaderWithAnchor id="select-catalog" level=2>Select report type (and catalog)</HeaderWithAnchor>
   </summary>
   <p>{helpText["catalog"]["intro"]}</p>
   {#each catalogChoices as catalogChoice}
@@ -136,6 +136,7 @@
 
         {catalogChoice.title}
       </label>
+      <HelpText type="catalog" field="{catalogChoice.catalog}" />
     </div>
   {/each}
 </details>

--- a/src/routes/About.svelte
+++ b/src/routes/About.svelte
@@ -23,6 +23,7 @@
   const location = useLocation();
   let catalog = getCatalog($evaluation.catalog);
   let catalogChoices = getListOfCatalogs();
+  let selectedCatalog = $evaluation.catalog;
 
   onMount(() => {
     currentPage.update(currentPage => "About");
@@ -84,12 +85,17 @@
   }
 
   function updateCatalog(e) {
+    selectedCatalog = e.target.value;
+  }
+
+  function confirmCatalogChange(e) {
     if (
       window.confirm(
         "Switching catalogs may remove entered data and notes from your ACR that are not part of the newly selected catalog. Please download your report before switching catalogs to avoid losing information. Select cancel to download your report from the Report page before proceeding. Are you sure that's what you'd like to do?"
       )
     ) {
-      updateEvaluation(e.target.value, $evaluation);
+      $evaluation['catalog'] = selectedCatalog;
+      updateEvaluation(selectedCatalog, $evaluation);
     }
   }
 
@@ -130,7 +136,7 @@
         <input
           type="radio"
           value={catalogChoice.catalog}
-          bind:group="{$evaluation['catalog']}"
+          bind:group="{selectedCatalog}"
           id="evaluation-catalog-{catalogChoice.catalog}"
           on:change={updateCatalog} />
 
@@ -139,6 +145,11 @@
       <HelpText type="catalog" field="{catalogChoice.catalog}" />
     </div>
   {/each}
+
+  {#if $evaluation['catalog'] !== selectedCatalog }
+    <p><em>Report type change is not saved till you confirm.</em></p>
+  {/if}
+  <button class="button" on:click={confirmCatalogChange} disabled={$evaluation['catalog'] === selectedCatalog}>Confirm</button>
 </details>
 
 <details open>

--- a/src/utils/getCatalogs.js
+++ b/src/utils/getCatalogs.js
@@ -20,15 +20,15 @@ export function getListOfCatalogs() {
   return [
     {
       catalog: wcag20508catalogName,
-      title: `${wcag20508catalog.title} (WCAG 2.0)`,
+      title: "VPAT® 2.4 508: Revised Section 508 Edition (WCAG 2.0)",
     },
     {
       catalog: wcag21508catalogName,
-      title: `${wcag21508catalog.title}`,
+      title: "VPAT® 2.4 508 + WCAG: Revised Section 508 Edition (WCAG 2.1)",
     },
     {
       catalog: wcag21catalogName,
-      title: `${wcag21catalog.title} (WCAG 2.1)`,
+      title: "VPAT® 2.4 WCAG: WCAG 2.1",
     },
   ];
 }

--- a/src/utils/getCatalogs.js
+++ b/src/utils/getCatalogs.js
@@ -34,5 +34,5 @@ export function getListOfCatalogs() {
 }
 
 export function getDefaultCatalogName() {
-  return wcag20508catalogName;
+  return wcag21508catalogName;
 }


### PR DESCRIPTION
Closes https://github.com/GSA/openacr/issues/340 and fixes https://github.com/GSA/openacr/issues/341

Summary of changes:
* Updated select catalog text.
* Moved confirmation to a button.
* Added reset button to go with the confirm button.
* Update tests to use the confirm button.
* Added tests for the checking the confirm and reset button dialogs and functionality.

**QA Help Text**

1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Click 'Start new report' or 'New report'.
3. On the about page confirm you see 'Select catalog' accordion.
4. Confirm the accordion is expanded and has a radio choices below the text 'Select which catalog you will be using for the OpenACR.'
5. Confirm the choice text and help text.
6. Switch the choice and click the 'Confirm' button and then confirm the dialog text.

**QA cancel change**

1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Click 'Start new report' or 'New report'.
3. On the about page confirm you see 'Select catalog' accordion.
4. Switch the choice and click the 'Confirm' button and then cancel the dialog text.
5. Switch to a chapter page or report page and confirm the catalog has not changed.
6. Switch back to the 'about' page and confirm the choice is reset to the existing one.

**QA new report**

1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Click 'Start new report' or 'New report'.
3. Switch the choice from WCAG 2.0 to any of the other choices.
4. Click the 'Confirm' button and confirm the change.
5. Confirm the chapters in the navigation changes and the sidebar changes when switching the choices.
7. Selecting WCAG 2.1 catalog.
8. Click the 'Confirm' button and confirm the change.
9. Navigate to the chapter pages and confirm you see WCAG 2.1 criteria and links go to WCAG 2.1 pages.
10. Add some text, select some values.
11. Click the 'View report' or 'Report' tab.
12. Confirm you see a green 'Valid Report' box at the top of the report page with the message 'Your report has passed validation'.
13. Confirm the report has the WCAG 2.1 criteria and links go to WCAG 2.1 pages.
14. Download the YAML & HTML report.
15. Confirm the report has the WCAG 2.1 criteria and links go to WCAG 2.1 pages.
16. Go back to the 'Overview' page
17. Click 'Start new report' or 'New report'.
18. Click 'Open report'.
19. Upload the downloaded YAML file from step 13.
20. Confirm the catalog selection shows the WCAG 2.1 selection.

**QA existing report**

1. After deployment ('Deploy' action) is successful, open site https://gsa.github.io/openacr-editor/.
2. Click 'Start new report' or 'New report'.
3. Click 'Open report'.
4. Upload a yaml file from OpenACR that already has 'last modified date' and 'version' set to some values (if needed modify the YAML file to set those values before uploading). Try the 'drupal-9.yaml' or any of the yaml files from https://github.com/GSA/openacr/tree/main/openacr where last modified date is 11/16/2021 and version is 12.
5. Confirm the catalog selection shows the WCAG 2.0 selection.
7. Switch the choice from WCAG 2.0 to any of the other choices.
8. Click the 'Confirm' button and confirm the change.
9. Navigate to the chapter pages and confirm you see WCAG 2.1 criteria and links go to WCAG 2.1 pages.
10. Add some text, select some values.
11. Click the 'View report' or 'Report' tab.
12. Confirm you see a green 'Valid Report' box at the top of the report page with the message 'Your report has passed validation'.
13. Confirm the report has the WCAG 2.1 criteria and links go to WCAG 2.1 pages.
14. Download the YAML & HTML report.
15. Confirm the report has the WCAG 2.1 criteria and links go to WCAG 2.1 pages.
16. Go back to the 'Overview' page
17. Click 'Start new report' or 'New report'.
18. Upload the downloaded YAML file from step 13.
19. Confirm the catalog selection shows the WCAG 2.1 selection.
20. Switch the choice back to WCAG 2.0.
21. Click the 'Confirm' button and confirm the change.
22. Navigate to the chapter pages and confirm you only see WCAG 2.0 criteria and links go to WCAG 2.0 pages.
23. Click the 'View report' or 'Report' tab.
24. Confirm you see a green 'Valid Report' box at the top of the report page with the message 'Your report has passed validation'.
25. Confirm the report has the only see WCAG 2.0 criteria and links go to WCAG 2.0 pages.