### PR TITLE
Preserve visually hidden text within license link

### DIFF
--- a/src/utils/license.js
+++ b/src/utils/license.js
@@ -7,7 +7,12 @@ export function license(evaluation, templateType) {
       return sanitizeHtml(
         `<a href="${spdxLicenseList[evaluation.license].url}" target="_blank">${
           spdxLicenseList[evaluation.license].name
-        } <span class="visuallyhidden">(opens in a new window or tab)</span></a>`
+        } <span class="visuallyhidden">(opens in a new window or tab)</span></a>`,
+        {
+          allowedClasses: {
+            'span': ['visuallyhidden'],
+          },
+        },
       );
     } else {
       return `[${spdxLicenseList[evaluation.license].name}](${


### PR DESCRIPTION
In the current editor output, the `sanitize-html` filtering causes the `visuallyhidden` class to be removed:

```html
<a href="https://creativecommons.org/publicdomain/zero/1.0/legalcode" target="_blank">
  Creative Commons Zero v1.0 Universal <span>(opens in a new window or tab)</span>
</a>
```

I looked at what might be the correct fix based on the [sanitize-html docs for `allowedClass`](https://www.npmjs.com/package/sanitize-html#allowed-css-classes), but didn’t actually test this code.

There are two alternative fixes here that might be better suited:

- Remove `sanitizeHtml` altogether. At least currently this code only outputs content from [spdx-license-list](https://www.npmjs.com/package/spdx-license-list), which I’d assume is trusted _enough_ with how they define URLs and license names.
- Remove the `target="_blank"` and `<span>(opens in a new window or tab)</span>` for simplicity.