### PR TITLE
Fix extra space in footer links

### DIFF
--- a/src/components/report/ReportZipDownload.svelte
+++ b/src/components/report/ReportZipDownload.svelte
@@ -140,7 +140,7 @@
       <div class="grid-container">
         <div class="grid-row grid-gap">
           <div class="grid-col">
-            <a href="https://github.com/GSA/openacr" target="_blank">OpenACR <span class="visuallyhidden">(opens in a new window or tab)</span></a> is a format maintained by the <a href="https://gsa.gov/" target="_blank">GSA <span class="visuallyhidden">(opens in a new window or tab)</span></a>. The content is the responsibility of the author.
+            <a href="https://github.com/GSA/openacr" target="_blank">OpenACR<span class="visuallyhidden"> (opens in a new window or tab)</span></a> is a format maintained by the <a href="https://gsa.gov/" target="_blank">GSA<span class="visuallyhidden"> (opens in a new window or tab)</span></a>. The content is the responsibility of the author.
           </div>
           <div class="grid-col">
             <ReportLicense />

--- a/src/utils/license.js
+++ b/src/utils/license.js
@@ -7,7 +7,7 @@ export function license(evaluation, templateType) {
       return sanitizeHtml(
         `<a href="${spdxLicenseList[evaluation.license].url}" target="_blank">${
           spdxLicenseList[evaluation.license].name
-        } <span class="visuallyhidden">(opens in a new window or tab)</span></a>`
+        }<span class="visuallyhidden"> (opens in a new window or tab)</span></a>`
       );
     } else {
       return `[${spdxLicenseList[evaluation.license].name}](${


### PR DESCRIPTION
This causes the links to appear over a space which isn’t elegant.