### PR TITLE
ECASOGP-11018: Remove path prefix to use subdomain

### DIFF
--- a/config/ghpages.json
+++ b/config/ghpages.json
@@ -1,3 +1,3 @@
 {
-  "pathPrefix": "/openacr-editor"
+  "pathPrefix": ""
 }


### PR DESCRIPTION
The pathPrefix setting has been changed to an empty value to have this website on the acreditor.section508.gov subdomain.